### PR TITLE
ci: add cross-repo gh-pages deploy workflow

### DIFF
--- a/.github/workflows/deploy-pages.yml
+++ b/.github/workflows/deploy-pages.yml
@@ -1,0 +1,87 @@
+# Deploy runbook: packages/web/README.md#deployment
+name: Deploy Pages
+
+on:
+  workflow_dispatch:
+  push:
+    branches:
+      - main
+    paths:
+      - .github/workflows/deploy-pages.yml
+      - package.json
+      - pnpm-lock.yaml
+      - pnpm-workspace.yaml
+      - packages/web/**
+
+permissions:
+  contents: read
+
+concurrency:
+  group: dantalion-web-demo-gh-pages
+  cancel-in-progress: true
+
+jobs:
+  deploy:
+    name: deploy to kurone-kito/dantalion@gh-pages
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    steps:
+      - uses: actions/checkout@v6
+
+      - uses: pnpm/action-setup@v6
+        with:
+          run_install: false
+
+      - uses: actions/setup-node@v6
+        with:
+          cache: pnpm
+          node-version: 24
+
+      - run: corepack enable
+
+      - env:
+          HUSKY: 0
+        run: pnpm install --frozen-lockfile --prefer-offline
+
+      - env:
+          BASE_PATH: /dantalion/
+        run: pnpm --filter @kurone-kito/dantalion-web-demo-web run build
+
+      - if: ${{ secrets.DANTALION_GH_PAGES_DEPLOY_KEY == '' }}
+        run: |
+          echo "::error::Missing secret DANTALION_GH_PAGES_DEPLOY_KEY. Resolve issue #14 before running Deploy Pages."
+          exit 1
+
+      - uses: actions/checkout@v6
+        with:
+          path: gh-pages
+          ref: gh-pages
+          repo: kurone-kito/dantalion
+          ssh-key: ${{ secrets.DANTALION_GH_PAGES_DEPLOY_KEY }}
+
+      - name: sync static output
+        run: |
+          rsync --archive --delete --exclude='.git' \
+            packages/web/.output/public/ \
+            gh-pages/
+
+      - name: commit and push deploy
+        env:
+          SOURCE_SHA: ${{ github.sha }}
+        working-directory: gh-pages
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+
+          git add --all
+
+          if git diff --cached --quiet; then
+            echo "No deploy changes detected."
+            exit 0
+          fi
+
+          short_sha="$(git -C "$GITHUB_WORKSPACE" rev-parse --short "$SOURCE_SHA")"
+          git commit \
+            -m "deploy: dantalion-web-demo @ ${short_sha}" \
+            -m "Co-Authored-By: github-actions[bot] <41898282+github-actions[bot]@users.noreply.github.com>"
+          git push origin gh-pages

--- a/packages/web/README.md
+++ b/packages/web/README.md
@@ -24,3 +24,33 @@ head. It resolves `localStorage["dantalion-web-demo:theme"]` first,
 falls back to `prefers-color-scheme`, and sets
 `document.documentElement.dataset.theme` before the client bundle
 hydrates to avoid a flash of the wrong DaisyUI theme.
+
+## Deployment
+
+`BASE_PATH=/dantalion/` controls the router and asset base used by the
+GitHub Pages build. The deploy workflow keeps that value fixed so the
+generated output matches `https://kurone-kito.github.io/dantalion/`.
+
+The cross-repo deploy workflow reads the secret
+`DANTALION_GH_PAGES_DEPLOY_KEY` and checks out
+`kurone-kito/dantalion@gh-pages` over SSH. Provisioning that deploy key
+is tracked separately in issue `#14`; until the secret exists, the
+workflow still runs the build and then fails fast before the deploy
+checkout.
+
+You can smoke-test the workflow locally with `act` by providing the same
+secret contract, for example:
+
+```sh
+act -j deploy --secret-file .secrets
+```
+
+Where `.secrets` contains:
+
+```sh
+DANTALION_GH_PAGES_DEPLOY_KEY='-----BEGIN OPENSSH PRIVATE KEY-----...'
+```
+
+Rollback is revert-first: revert the offending push to `main`, then
+re-run `Deploy Pages`. The workflow syncs the current build output into
+`gh-pages` without force-pushing over the branch history.


### PR DESCRIPTION
## Summary

Add `.github/workflows/deploy-pages.yml` that publishes the static build
to `kurone-kito/dantalion@gh-pages` on every push to `main` (or on
manual dispatch), preserving the `https://kurone-kito.github.io/dantalion/`
homepage URL.

Implements #13.

## What landed

- `.github/workflows/deploy-pages.yml` —
  - Triggers: `push: { branches: [main] }`, `workflow_dispatch`
  - Build: `pnpm install --frozen-lockfile` → `pnpm --filter web run build` with `BASE_PATH=/dantalion/`
  - Cross-repo checkout of `kurone-kito/dantalion` at `gh-pages` via
    `ssh-key: ${{ secrets.DANTALION_GH_PAGES_DEPLOY_KEY }}`
  - Sync output → `gh-pages` working tree with `rsync --archive --delete --exclude='.git'`
  - Commit (`deploy: dantalion-web-demo @ <short-sha>`) + push
  - `concurrency` group `dantalion-web-demo-gh-pages` with `cancel-in-progress: true`
- `packages/web/README.md` — points operators at #14 for the secret
  provisioning runbook

## Operator dependency

The actual deploy run is gated on the SSH deploy key tracked in #14
(`blocked-by-human`). Without it the workflow fails at the cross-repo
checkout step with a clear "missing secret" error rather than silently
no-op'ing.

## Test plan

- [x] Workflow YAML lints cleanly via Biome
- [x] `pnpm run lint` exits zero
- [ ] CI matrix green — verified post-merge
- [ ] Successful run after #14 provisions `DANTALION_GH_PAGES_DEPLOY_KEY`

Closes #13

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Implemented automated GitHub Pages deployment workflow with concurrency management and early failure detection.

* **Documentation**
  * Added deployment guide covering base path configuration, workflow execution, secret management requirements, and rollback procedures.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/kurone-kito/dantalion-web-demo/pull/23?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->