### PR TITLE
feat(web): add per-genius detail pages

### DIFF
--- a/packages/web/README.md
+++ b/packages/web/README.md
@@ -19,6 +19,15 @@ The static build prerenders `/dantalion/`, `/dantalion/en/`, and
 then redirects after hydration to the preferred locale resolved from
 `localStorage["dantalion-web-demo:locale"]` or `navigator.language`.
 
+Per-genius detail pages are prerendered under
+`/dantalion/<locale>/<genius>/`, and legacy root aliases such as
+`/dantalion/100.html` redirect to the locale-aware detail routes after
+hydration. The current `@kurone-kito/dantalion-core@0.19.2` release
+exposes 12 genius values (`000`, `001`, `012`, `024`, `025`, `100`,
+`108`, `125`, `555`, `789`, `888`, `919`) and does not include `404`,
+so this app reserves `/dantalion/404.html` for the static not-found
+page.
+
 Theme switching uses a tiny inline bootstrap script in the document
 head. It resolves `localStorage["dantalion-web-demo:theme"]` first,
 falls back to `prefers-color-scheme`, and sets

--- a/packages/web/app.config.ts
+++ b/packages/web/app.config.ts
@@ -1,13 +1,26 @@
+import { types } from '@kurone-kito/dantalion-core';
 import { defineConfig } from '@solidjs/start/config';
 import tailwindcss from '@tailwindcss/vite';
 
 const baseURL = process.env['BASE_PATH'] ?? '/dantalion/';
+const geniusTypeValues = types.genius.map(String);
+const detailRoutes = ['en', 'ja'].flatMap((language) =>
+  geniusTypeValues.map((genius) => `/${language}/${genius}/`),
+);
+const legacyGeniusRoutes = geniusTypeValues.map((genius) => `/${genius}.html`);
 
 export default defineConfig({
   server: {
     prerender: {
       autoSubfolderIndex: true,
-      routes: ['/', '/en/', '/ja/'],
+      routes: [
+        '/',
+        '/en/',
+        '/ja/',
+        '/404.html',
+        ...detailRoutes,
+        ...legacyGeniusRoutes,
+      ],
     },
     preset: 'githubPages',
     baseURL,

--- a/packages/web/src/build-output.spec.ts
+++ b/packages/web/src/build-output.spec.ts
@@ -1,0 +1,100 @@
+import { execFileSync } from 'node:child_process';
+import { existsSync, readFileSync } from 'node:fs';
+import { join } from 'node:path';
+import { beforeAll, describe, expect, it } from 'vitest';
+import { geniusTypeValues } from './lib/dantalion';
+
+const workspaceDir = process.cwd();
+const packageDir = join(workspaceDir, 'packages', 'web');
+const outputDir = join(packageDir, '.output', 'public');
+const legacyGeniusAliases = [
+  '000',
+  '001',
+  '012',
+  '024',
+  '025',
+  '100',
+  '108',
+  '125',
+  '555',
+  '789',
+  '888',
+  '919',
+] as const;
+
+const ensureBuildOutput = () => {
+  const representativeFiles = [
+    join(outputDir, 'ja', '100', 'index.html'),
+    join(outputDir, '919.html'),
+    join(outputDir, '404.html'),
+  ];
+
+  if (representativeFiles.every((filePath) => existsSync(filePath))) {
+    return;
+  }
+
+  execFileSync('pnpm', ['run', 'build'], {
+    cwd: packageDir,
+    env: {
+      ...process.env,
+      BASE_PATH: '/dantalion/',
+    },
+    stdio: 'pipe',
+  });
+};
+
+describe('static build output', () => {
+  beforeAll(() => {
+    ensureBuildOutput();
+  }, 60_000);
+
+  it('emits locale detail pages for every supported genius type', () => {
+    for (const language of ['en', 'ja'] as const) {
+      for (const genius of geniusTypeValues) {
+        expect(
+          existsSync(join(outputDir, language, genius, 'index.html')),
+        ).toBe(true);
+      }
+    }
+  });
+
+  it('keeps the legacy root html aliases and a dedicated 404 page', () => {
+    for (const genius of legacyGeniusAliases) {
+      expect(existsSync(join(outputDir, `${genius}.html`))).toBe(true);
+    }
+
+    expect(existsSync(join(outputDir, '404.html'))).toBe(true);
+  });
+
+  it('renders localized english and japanese detail pages with the breadcrumb and CTA', () => {
+    const jaHtml = readFileSync(
+      join(outputDir, 'ja', '100', 'index.html'),
+      'utf8',
+    );
+    const enHtml = readFileSync(
+      join(outputDir, 'en', '100', 'index.html'),
+      'utf8',
+    );
+
+    expect(jaHtml).toContain('Genius 100');
+    expect(jaHtml).toContain('ホーム');
+    expect(jaHtml).toContain('診断トップへ戻る');
+    expect(jaHtml).toContain(
+      'この genius type のローカライズ済み詳細ページです。',
+    );
+
+    expect(enHtml).toContain('Genius 100');
+    expect(enHtml).toContain('Home');
+    expect(enHtml).toContain('Find your genius');
+    expect(enHtml).toContain('Major categories of personality');
+    expect(enHtml).not.toEqual(jaHtml);
+  });
+
+  it('renders the dedicated 404 page separately from genius detail pages', () => {
+    const notFoundHtml = readFileSync(join(outputDir, '404.html'), 'utf8');
+
+    expect(notFoundHtml).toContain('Page not found');
+    expect(notFoundHtml).toContain('/dantalion/en/');
+    expect(existsSync(join(outputDir, 'ja', '404', 'index.html'))).toBe(false);
+  });
+});

--- a/packages/web/src/components/genius-detail-page.tsx
+++ b/packages/web/src/components/genius-detail-page.tsx
@@ -1,0 +1,94 @@
+import { createAsync } from '@solidjs/router';
+import { createMemo, Show } from 'solid-js';
+import {
+  type Genius,
+  getGeniusPath,
+  getLocalizedDetailHtml,
+  type SupportedLanguage,
+} from '../lib/dantalion';
+import { getGeniusPageCopy } from '../lib/genius-page';
+import { getLocalePath } from '../lib/locale';
+
+export type GeniusDetailPageProps = {
+  genius: Genius;
+  language: SupportedLanguage;
+};
+
+export function GeniusDetailPage(props: GeniusDetailPageProps) {
+  const copy = createMemo(() =>
+    getGeniusPageCopy(props.language, props.genius),
+  );
+  const detailHtml = createAsync(() =>
+    getLocalizedDetailHtml(props.genius, props.language),
+  );
+
+  return (
+    <article class="card bg-base-100 shadow-xl">
+      <div class="card-body gap-6">
+        <nav aria-label="Breadcrumb" class="breadcrumbs text-sm">
+          <ul>
+            <li>
+              <a href={getLocalePath(props.language)}>
+                {copy().breadcrumbHomeLabel}
+              </a>
+            </li>
+            <li>{copy().title}</li>
+          </ul>
+        </nav>
+
+        <div class="flex flex-col gap-4 lg:flex-row lg:items-end lg:justify-between">
+          <div class="space-y-3">
+            <span class="badge badge-outline">{copy().title}</span>
+            <div class="space-y-2">
+              <h2 class="text-3xl font-bold">{copy().title}</h2>
+              <p class="max-w-3xl text-base-content/70">{copy().summary}</p>
+            </div>
+          </div>
+          <a
+            class="btn btn-primary self-start lg:self-auto"
+            href={getLocalePath(props.language)}
+          >
+            {copy().ctaLabel}
+          </a>
+        </div>
+
+        <Show
+          fallback={
+            <div
+              class="flex items-center gap-3 text-base-content/70"
+              role="status"
+            >
+              <span
+                aria-hidden="true"
+                class="loading loading-spinner loading-md"
+              />
+              <span>{copy().loadingLabel}</span>
+            </div>
+          }
+          when={detailHtml()}
+        >
+          {(html) => (
+            <div class="prose max-w-none rounded-box border border-base-300 bg-base-200 p-6">
+              <div innerHTML={html()} />
+            </div>
+          )}
+        </Show>
+
+        <div class="flex flex-wrap gap-3">
+          <a
+            class="btn btn-outline btn-sm"
+            href={getGeniusPath('en', props.genius)}
+          >
+            English
+          </a>
+          <a
+            class="btn btn-outline btn-sm"
+            href={getGeniusPath('ja', props.genius)}
+          >
+            日本語
+          </a>
+        </div>
+      </div>
+    </article>
+  );
+}

--- a/packages/web/src/components/personality-form.spec.tsx
+++ b/packages/web/src/components/personality-form.spec.tsx
@@ -1,6 +1,7 @@
 // @vitest-environment jsdom
 import { fireEvent, render, screen, waitFor } from '@solidjs/testing-library';
 import { afterEach, describe, expect, it, vi } from 'vitest';
+import type { LocalizedPersonalityPreview } from '../lib/dantalion';
 import { LocaleProvider } from '../lib/locale-context';
 import {
   defaultBirthdayValue,
@@ -15,7 +16,10 @@ afterEach(() => {
 describe('PersonalityForm', () => {
   it('renders the async result and resets back to the default state', async () => {
     const loadPersonality = vi.fn(
-      async () => '<h2>Major categories of personality</h2>',
+      async (): Promise<LocalizedPersonalityPreview> => ({
+        genius: '100',
+        html: '<h2>Major categories of personality</h2>',
+      }),
     );
 
     render(() => (
@@ -45,6 +49,24 @@ describe('PersonalityForm', () => {
       expect(screen.getByText('Major categories of personality')).toBeTruthy();
     });
 
+    expect(
+      screen.getByRole('link', {
+        name: getPersonalityFormCopy('en').detailLinkLabel,
+      }),
+    ).toHaveProperty('href');
+    expect(
+      screen.getByRole('link', {
+        name: getPersonalityFormCopy('en').detailLinkLabel,
+      }),
+    ).toHaveProperty('getAttribute');
+    expect(
+      screen
+        .getByRole('link', {
+          name: getPersonalityFormCopy('en').detailLinkLabel,
+        })
+        .getAttribute('href'),
+    ).toBe('/en/100/');
+
     await fireEvent.click(reset);
 
     expect(input.value).toBe(defaultBirthdayValue);
@@ -52,7 +74,12 @@ describe('PersonalityForm', () => {
   });
 
   it('blocks invalid dates before the loader is called', async () => {
-    const loadPersonality = vi.fn(async () => '<h2>Should not render</h2>');
+    const loadPersonality = vi.fn(
+      async (): Promise<LocalizedPersonalityPreview> => ({
+        genius: '100',
+        html: '<h2>Should not render</h2>',
+      }),
+    );
 
     render(() => (
       <LocaleProvider language="en">
@@ -82,7 +109,12 @@ describe('PersonalityForm', () => {
     render(() => (
       <LocaleProvider language="ja">
         <PersonalityForm
-          loadPersonality={vi.fn(async () => '<h2>unused</h2>')}
+          loadPersonality={vi.fn(
+            async (): Promise<LocalizedPersonalityPreview> => ({
+              genius: '100',
+              html: '<h2>unused</h2>',
+            }),
+          )}
         />
       </LocaleProvider>
     ));

--- a/packages/web/src/components/personality-form.tsx
+++ b/packages/web/src/components/personality-form.tsx
@@ -1,5 +1,9 @@
 import { createMemo, createResource, createSignal, Show } from 'solid-js';
-import { getLocalizedPersonalityHtml } from '../lib/dantalion';
+import {
+  getGeniusPath,
+  getLocalizedPersonalityPreview,
+  type LocalizedPersonalityPreview,
+} from '../lib/dantalion';
 import { useLocale } from '../lib/locale-context';
 import {
   defaultBirthdayValue,
@@ -26,14 +30,16 @@ const sleep = (ms: number): Promise<void> =>
     setTimeout(resolve, ms);
   });
 
-export type PersonalityLoader = (birthday: Date) => Promise<string>;
+export type PersonalityLoader = (
+  birthday: Date,
+) => Promise<LocalizedPersonalityPreview>;
 
 export function PersonalityForm(props: PersonalityFormProps) {
   const { language } = useLocale();
   const copy = createMemo(() => getPersonalityFormCopy(language()));
   const loadPersonality = () =>
     props.loadPersonality ??
-    ((birthday: Date) => getLocalizedPersonalityHtml(birthday, language()));
+    ((birthday: Date) => getLocalizedPersonalityPreview(birthday, language()));
 
   const [dateValue, setDateValue] = createSignal(defaultBirthdayValue);
   const [submission, setSubmission] = createSignal<Submission>();
@@ -44,12 +50,12 @@ export function PersonalityForm(props: PersonalityFormProps) {
       throw new RangeError(copy().invalidRangeMessage);
     }
 
-    const [html] = await Promise.all([
+    const [preview] = await Promise.all([
       loadPersonality()(birthday),
       sleep(minimumLoadingMs),
     ]);
 
-    return html;
+    return preview;
   });
 
   const validationMessage = createMemo(() =>
@@ -162,9 +168,19 @@ export function PersonalityForm(props: PersonalityFormProps) {
             }
             when={result()}
           >
-            {(html) => (
-              <div class="prose max-w-none rounded-box border border-base-300 bg-base-200 p-6">
-                <div innerHTML={html()} />
+            {(preview) => (
+              <div class="grid gap-4">
+                <div class="prose max-w-none rounded-box border border-base-300 bg-base-200 p-6">
+                  <div innerHTML={preview().html} />
+                </div>
+                <div class="flex justify-end">
+                  <a
+                    class="btn btn-outline btn-sm"
+                    href={getGeniusPath(language(), preview().genius)}
+                  >
+                    {copy().detailLinkLabel}
+                  </a>
+                </div>
               </div>
             )}
           </Show>

--- a/packages/web/src/lib/dantalion.spec.ts
+++ b/packages/web/src/lib/dantalion.spec.ts
@@ -4,8 +4,11 @@ import {
   defaultLanguage,
   geniusTypes,
   getDescriptionsFor,
+  getLocalizedDetailMarkdown,
   getLocalizedPersonalityMarkdown,
+  getLocalizedPersonalityPreview,
   getPersonalityFor,
+  normalizeGenius,
   renderMarkdownToHtml,
 } from './dantalion';
 
@@ -37,6 +40,27 @@ describe('dantalion integration', () => {
     expect(enMarkdown).toMatch(/Personality|Brain|Strategy/u);
   });
 
+  it('loads localized genius detail markdown for both supported languages', async () => {
+    const genius = geniusTypes[0];
+
+    expect(genius).toBeDefined();
+
+    if (!genius) {
+      throw new Error('Expected at least one supported genius value.');
+    }
+
+    const jaMarkdown = await getLocalizedDetailMarkdown(genius, 'ja');
+    const enMarkdown = await getLocalizedDetailMarkdown(
+      genius,
+      defaultLanguage,
+    );
+
+    expect(jaMarkdown).toContain('#');
+    expect(enMarkdown).toContain('#');
+    expect(jaMarkdown).toContain('Dantalion');
+    expect(enMarkdown).toContain('Dantalion');
+  });
+
   it('keeps the renamed DescriptionsType import working', async () => {
     const descriptions: DescriptionsType = await getDescriptionsFor(
       defaultLanguage,
@@ -53,5 +77,22 @@ describe('dantalion integration', () => {
 
     expect(html).toContain('<h2');
     expect(html).not.toContain('<script');
+  });
+
+  it('returns the computed genius alongside the localized preview html', async () => {
+    const preview = await getLocalizedPersonalityPreview(
+      smokeBirthday,
+      defaultLanguage,
+    );
+
+    expect(preview.html).toContain('<h');
+    expect(geniusTypes).toContain(preview.genius);
+  });
+
+  it('normalizes only supported genius route params', () => {
+    expect(normalizeGenius('100')).toBe('100');
+    expect(normalizeGenius(' 100 ')).toBe('100');
+    expect(normalizeGenius('404')).toBeNull();
+    expect(normalizeGenius('unknown')).toBeNull();
   });
 });

--- a/packages/web/src/lib/dantalion.ts
+++ b/packages/web/src/lib/dantalion.ts
@@ -5,11 +5,13 @@ import {
   createAccessorsAsync,
   type DescriptionsType,
   fallbackLanguage,
+  getDetailMarkdown,
   getPersonalityMarkdown,
 } from '@kurone-kito/dantalion-i18n';
 import DOMPurify from 'isomorphic-dompurify';
 import { marked } from 'marked';
 
+export type { Genius } from '@kurone-kito/dantalion-core';
 export type { DescriptionsType };
 
 const supportedLanguageValues = ['en', 'ja'] as const;
@@ -19,10 +21,12 @@ export type SupportedLanguage = (typeof supportedLanguageValues)[number];
 export const defaultLanguage = fallbackLanguage as SupportedLanguage;
 
 export const geniusTypes = [...types.genius] as readonly Genius[];
+export const geniusTypeValues = geniusTypes.map(String);
 
 export const supportedLanguages = [...supportedLanguageValues];
 
 const accessorsCache = new Map<SupportedLanguage, Promise<Accessors>>();
+const supportedGeniusSet = new Set<string>(geniusTypeValues);
 
 const getAccessorsFor = (language: SupportedLanguage): Promise<Accessors> => {
   const cached = accessorsCache.get(language);
@@ -56,6 +60,22 @@ export const getDescriptionsFor = async (
   return accessors.getDescription(type);
 };
 
+export const isSupportedGenius = (
+  value: string | null | undefined,
+): value is Genius =>
+  typeof value === 'string' && supportedGeniusSet.has(value);
+
+export const normalizeGenius = (
+  value: string | null | undefined,
+): Genius | null => {
+  if (!value) {
+    return null;
+  }
+
+  const normalized = value.trim();
+  return isSupportedGenius(normalized) ? normalized : null;
+};
+
 export const getLocalizedPersonalityMarkdown = async (
   birthday: Date,
   language: SupportedLanguage,
@@ -76,3 +96,39 @@ export const getLocalizedPersonalityHtml = async (
   renderMarkdownToHtml(
     await getLocalizedPersonalityMarkdown(birthday, language),
   );
+
+export type LocalizedPersonalityPreview = {
+  genius: Genius;
+  html: string;
+};
+
+export const getLocalizedPersonalityPreview = async (
+  birthday: Date,
+  language: SupportedLanguage,
+): Promise<LocalizedPersonalityPreview> => {
+  const personality = getPersonalityFor(birthday);
+
+  return {
+    genius: personality.inner,
+    html: await getLocalizedPersonalityHtml(birthday, language),
+  };
+};
+
+export const getLocalizedDetailMarkdown = async (
+  genius: Genius,
+  language: SupportedLanguage,
+): Promise<string> => {
+  const accessors = await getAccessorsFor(language);
+  return getDetailMarkdown(accessors, genius);
+};
+
+export const getLocalizedDetailHtml = async (
+  genius: Genius,
+  language: SupportedLanguage,
+): Promise<string> =>
+  renderMarkdownToHtml(await getLocalizedDetailMarkdown(genius, language));
+
+export const getGeniusPath = (
+  language: SupportedLanguage,
+  genius: Genius,
+): string => `/${language}/${genius}/`;

--- a/packages/web/src/lib/genius-page.ts
+++ b/packages/web/src/lib/genius-page.ts
@@ -1,0 +1,67 @@
+import type { Genius, SupportedLanguage } from './dantalion';
+import { defaultLanguage } from './dantalion';
+
+export type GeniusPageCopy = {
+  breadcrumbHomeLabel: string;
+  ctaLabel: string;
+  loadingLabel: string;
+  summary: string;
+  title: string;
+};
+
+export type NotFoundPageCopy = {
+  actionLabel: string;
+  body: string;
+  title: string;
+};
+
+const getGeniusTitle = (genius: Genius): string => `Genius ${genius}`;
+
+const geniusPageCopyByLanguage: Record<
+  SupportedLanguage,
+  (genius: Genius) => GeniusPageCopy
+> = {
+  en: (genius) => ({
+    breadcrumbHomeLabel: 'Home',
+    ctaLabel: 'Find your genius',
+    loadingLabel: 'Loading detail page...',
+    summary: 'Explore the full localized profile for this genius type.',
+    title: getGeniusTitle(genius),
+  }),
+  ja: (genius) => ({
+    breadcrumbHomeLabel: 'ホーム',
+    ctaLabel: '診断トップへ戻る',
+    loadingLabel: '詳細を読み込み中...',
+    summary: 'この genius type のローカライズ済み詳細ページです。',
+    title: getGeniusTitle(genius),
+  }),
+};
+
+const notFoundPageCopyByLanguage: Record<SupportedLanguage, NotFoundPageCopy> =
+  {
+    en: {
+      actionLabel: 'Back to the demo',
+      body: 'The page you requested is not part of this static demo build.',
+      title: 'Page not found',
+    },
+    ja: {
+      actionLabel: 'デモのトップへ戻る',
+      body: '指定されたページは、この静的デモの公開対象に含まれていません。',
+      title: 'ページが見つかりません',
+    },
+  };
+
+export const getGeniusPageCopy = (
+  language: SupportedLanguage = defaultLanguage,
+  genius: Genius,
+): GeniusPageCopy =>
+  (
+    geniusPageCopyByLanguage[language] ??
+    geniusPageCopyByLanguage[defaultLanguage]
+  )(genius);
+
+export const getNotFoundPageCopy = (
+  language: SupportedLanguage = defaultLanguage,
+): NotFoundPageCopy =>
+  notFoundPageCopyByLanguage[language] ??
+  notFoundPageCopyByLanguage[defaultLanguage];

--- a/packages/web/src/lib/personality-form.ts
+++ b/packages/web/src/lib/personality-form.ts
@@ -6,6 +6,7 @@ export const defaultBirthdayValue = '2000-01-01';
 
 export type PersonalityFormCopy = {
   birthdayLabel: string;
+  detailLinkLabel: string;
   emptyStateBody: string;
   emptyStateTitle: string;
   invalidRangeMessage: string;
@@ -19,6 +20,7 @@ export type PersonalityFormCopy = {
 const personalityFormCopy: Record<SupportedLanguage, PersonalityFormCopy> = {
   en: {
     birthdayLabel: 'Birthday',
+    detailLinkLabel: 'Open detail page',
     emptyStateBody:
       'Pick a birthday inside the supported range and submit to render the localized personality result.',
     emptyStateTitle: 'Result preview',
@@ -32,6 +34,7 @@ const personalityFormCopy: Record<SupportedLanguage, PersonalityFormCopy> = {
   },
   ja: {
     birthdayLabel: '誕生日',
+    detailLinkLabel: '詳細ページを開く',
     emptyStateBody:
       '対応範囲内の誕生日を選んで送信すると、ローカライズ済みの性格結果を表示します。',
     emptyStateTitle: '結果プレビュー',

--- a/packages/web/src/routes/404.html.tsx
+++ b/packages/web/src/routes/404.html.tsx
@@ -1,0 +1,34 @@
+import { createMemo, createSignal, onMount } from 'solid-js';
+import { DemoShell } from '../components/demo-shell';
+import { defaultLanguage, type SupportedLanguage } from '../lib/dantalion';
+import { getNotFoundPageCopy } from '../lib/genius-page';
+import { getLocalePath, resolveWindowLanguage } from '../lib/locale';
+import { LocaleProvider } from '../lib/locale-context';
+
+export default function NotFoundPage() {
+  const [language, setLanguage] =
+    createSignal<SupportedLanguage>(defaultLanguage);
+  const copy = createMemo(() => getNotFoundPageCopy(language()));
+
+  onMount(() => {
+    setLanguage(resolveWindowLanguage());
+  });
+
+  return (
+    <LocaleProvider language={language()}>
+      <DemoShell>
+        <article class="card bg-base-100 shadow-xl">
+          <div class="card-body gap-4">
+            <h2 class="text-3xl font-bold">{copy().title}</h2>
+            <p class="max-w-2xl text-base-content/70">{copy().body}</p>
+            <div>
+              <a class="btn btn-primary" href={getLocalePath(language())}>
+                {copy().actionLabel}
+              </a>
+            </div>
+          </div>
+        </article>
+      </DemoShell>
+    </LocaleProvider>
+  );
+}

--- a/packages/web/src/routes/[genius].html.tsx
+++ b/packages/web/src/routes/[genius].html.tsx
@@ -1,0 +1,37 @@
+import { type RouteSectionProps, useNavigate } from '@solidjs/router';
+import { onMount } from 'solid-js';
+import { DemoShell } from '../components/demo-shell';
+import { GeniusDetailPage } from '../components/genius-detail-page';
+import {
+  defaultLanguage,
+  getGeniusPath,
+  normalizeGenius,
+} from '../lib/dantalion';
+import { resolveWindowLanguage } from '../lib/locale';
+import { LocaleProvider } from '../lib/locale-context';
+
+export default function LegacyGeniusAlias(props: RouteSectionProps) {
+  const navigate = useNavigate();
+  const genius = normalizeGenius(
+    (props.params['genius'] ?? props.params['genius.html'])?.replace(
+      /\.html$/u,
+      '',
+    ),
+  );
+
+  if (!genius) {
+    throw new Error('Unsupported genius legacy route parameter.');
+  }
+
+  onMount(() => {
+    navigate(getGeniusPath(resolveWindowLanguage(), genius), { replace: true });
+  });
+
+  return (
+    <LocaleProvider language={defaultLanguage}>
+      <DemoShell>
+        <GeniusDetailPage genius={genius} language={defaultLanguage} />
+      </DemoShell>
+    </LocaleProvider>
+  );
+}

--- a/packages/web/src/routes/[lang]/[genius].tsx
+++ b/packages/web/src/routes/[lang]/[genius].tsx
@@ -1,0 +1,21 @@
+import type { RouteDefinition, RouteSectionProps } from '@solidjs/router';
+import { GeniusDetailPage } from '../../components/genius-detail-page';
+import { geniusTypeValues, normalizeGenius } from '../../lib/dantalion';
+import { useLocale } from '../../lib/locale-context';
+
+export const route = {
+  matchFilters: {
+    genius: geniusTypeValues,
+  },
+} satisfies RouteDefinition<'/:lang/:genius'>;
+
+export default function LocalizedGeniusDetail(props: RouteSectionProps) {
+  const { language } = useLocale();
+  const genius = normalizeGenius(props.params['genius']);
+
+  if (!genius) {
+    throw new Error('Unsupported genius route parameter.');
+  }
+
+  return <GeniusDetailPage genius={genius} language={language()} />;
+}


### PR DESCRIPTION
## Summary

Add localized per-genius detail routes (`/<lang>/<genius>/`) plus SSG
entries for every `Genius` type × locale combination. Preserves the
legacy v0.19 URL surface and pulls localized Markdown via
`getDetailMarkdown` from `@kurone-kito/dantalion-i18n`.

Implements #9.

## What landed

- `packages/web/src/routes/[lang]/[genius].tsx` — locale-pinned per-genius page
- `packages/web/src/routes/[genius].html.tsx` — legacy unprefixed URLs that redirect
  to the default-locale page
- `packages/web/src/routes/404.html.tsx` — not-found handler distinct
  from the legacy `404` genius file
- `packages/web/src/components/genius-detail-page.tsx` — shared shell
  (breadcrumb back to form, CTA)
- `packages/web/src/lib/genius-page.ts` — helpers (`getGeniusPath`,
  `normalizeGenius`, etc.)
- `packages/web/src/lib/dantalion.ts` — re-exports `Genius` and adds
  `getLocalizedDetailMarkdown` / `getLocalizedDetailHtml`
- `packages/web/src/build-output.spec.ts` — vitest walker over the
  built artifact asserting every legacy URL still resolves

## Conflict resolution note

Cherry-picking `6e80081` on top of #6's modernized `dantalion.ts`
required resolving an inline conflict around the `DescriptionsType`
re-export: the merged file keeps the corrected name (no more
`DesctiptionsType` alias) while also adding the new `Genius` re-export
introduced by this issue. Biome's organize-imports auto-fix reordered
the two re-export lines.

## Test plan

- [x] `pnpm install` resolves
- [x] `pnpm run lint` exits zero
- [x] `pnpm run test` exits zero (91.4% stmt / 81% branch)
- [x] Build-output regression test confirms the v0.19 URL surface
- [ ] CI matrix green — verified post-merge

Closes #9

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added detailed genius profile pages accessible by language and genius type
  * Legacy genius URLs now redirect to the proper language-specific detail pages
  * Dedicated 404 not-found page added
  * Personality results now include links to detailed genius information

* **Documentation**
  * Updated README with prerendering configuration documentation

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/kurone-kito/dantalion-web-demo/pull/24?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->