### PR TITLE
fix(ci): step-level secrets context broke deploy-pages workflow parse

### DIFF
--- a/.github/workflows/deploy-pages.yml
+++ b/.github/workflows/deploy-pages.yml
@@ -47,10 +47,14 @@ jobs:
           BASE_PATH: /dantalion/
         run: pnpm --filter @kurone-kito/dantalion-web-demo-web run build
 
-      - if: ${{ secrets.DANTALION_GH_PAGES_DEPLOY_KEY == '' }}
+      - name: ensure deploy key secret is set
+        env:
+          DEPLOY_KEY: ${{ secrets.DANTALION_GH_PAGES_DEPLOY_KEY }}
         run: |
-          echo "::error::Missing secret DANTALION_GH_PAGES_DEPLOY_KEY. Resolve issue #14 before running Deploy Pages."
-          exit 1
+          if [ -z "$DEPLOY_KEY" ]; then
+            echo "::error::Missing secret DANTALION_GH_PAGES_DEPLOY_KEY. Resolve issue #14 before running Deploy Pages."
+            exit 1
+          fi
 
       - uses: actions/checkout@v6
         with:


### PR DESCRIPTION
## Summary

Fix a parse-time bug in `.github/workflows/deploy-pages.yml` (introduced
in #23) that prevented the workflow from running at all — including the
operator-triggered smoke test after the deploy key was provisioned for
#14.

## What was broken

```yaml
- if: ${{ secrets.DANTALION_GH_PAGES_DEPLOY_KEY == '' }}
  run: |
    echo "::error::Missing secret DANTALION_GH_PAGES_DEPLOY_KEY..."
    exit 1
```

GitHub Actions does **not** expose the `secrets` context inside a
step-level `if:` expression, so this expression fails the workflow
parse phase. Symptoms observed:

- `workflow_dispatch` returned HTTP 422 with `Unrecognized named-value:
  'secrets'`
- Every push to `main` since #23 merged produced a `conclusion:
  "failure"` run that never executed any step

## Fix

Move the secret into a step-level `env:` (which **is** the documented
pattern) and gate via a shell check. The `secrets.*` lookup is still
written verbatim — it just lives in `env:` instead of `if:`:

```yaml
- name: ensure deploy key secret is set
  env:
    DEPLOY_KEY: ${{ secrets.DANTALION_GH_PAGES_DEPLOY_KEY }}
  run: |
    if [ -z "$DEPLOY_KEY" ]; then
      echo "::error::Missing secret DANTALION_GH_PAGES_DEPLOY_KEY..."
      exit 1
    fi
```

Both the existing-secret path and the missing-secret guard now work,
and the deploy job can finally reach the cross-repo checkout.

## Test plan

- [x] `pnpm run lint` exits zero
- [ ] Workflow accepts `gh workflow run deploy-pages.yml --ref main` —
      verified after merge
- [ ] First successful deploy lands on `kurone-kito/dantalion@gh-pages`
      and renders at `https://kurone-kito.github.io/dantalion/`

Refs #14

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved deployment workflow validation to explicitly check for required credentials and fail fast if missing, reducing the risk of silent deployment failures.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/kurone-kito/dantalion-web-demo/pull/28?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->