### PR TITLE
fix(ci): use 'repository' input in cross-repo checkout

### DIFF
--- a/.github/workflows/deploy-pages.yml
+++ b/.github/workflows/deploy-pages.yml
@@ -60,7 +60,7 @@ jobs:
         with:
           path: gh-pages
           ref: gh-pages
-          repo: kurone-kito/dantalion
+          repository: kurone-kito/dantalion
           ssh-key: ${{ secrets.DANTALION_GH_PAGES_DEPLOY_KEY }}
 
       - name: sync static output


### PR DESCRIPTION
## Summary

Smoke-testing the deploy workflow after #28 unblocked it surfaced a
second pre-existing bug: the cross-repo `actions/checkout@v6` step used
`repo:` for the target repository, but the canonical input name in v6
is `repository:`.

Symptoms in the latest [`workflow_dispatch` run](https://github.com/kurone-kito/dantalion-web-demo/actions/runs/26193173275):

```
! Unexpected input(s) 'repo', valid inputs are ['repository', 'ref',
  'token', 'ssh-key', 'ssh-known-hosts', 'ssh-strict', 'ssh-user',
  'persist-credentials', 'path', 'clean', 'filter', 'sparse-checkout',
  'sparse-checkout-cone-mode', 'fetch-depth', 'fetch-tags',
  'show-progress', 'lfs', 'submodules', 'set-safe-directory',
  'github-server-url']
X The process '/usr/bin/git' failed with exit code 1
```

Because the unrecognized input is silently ignored, the second checkout
defaulted to the **current** repository and then asked for a
`gh-pages` ref that does not exist on `kurone-kito/dantalion-web-demo`,
producing the exit-1 git failure.

## Fix

Rename the input:

```diff
- repo: kurone-kito/dantalion
+ repository: kurone-kito/dantalion
```

## Test plan

- [x] `pnpm run lint` exits zero
- [ ] `gh workflow run deploy-pages.yml --ref main` finishes green —
      verified after merge
- [ ] `kurone-kito/dantalion@gh-pages` head is updated by
      `github-actions[bot]` with `deploy: dantalion-web-demo @ <sha>`

Refs #14

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated internal deployment workflow configuration to ensure consistent repository identification during the deployment process.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/kurone-kito/dantalion-web-demo/pull/29?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->