### PR TITLE
feat(web): add a thin web-only i18n layer

### DIFF
--- a/packages/web/src/i18n/locales/en.json
+++ b/packages/web/src/i18n/locales/en.json
@@ -1,0 +1,37 @@
+{
+  "demoPage": {
+    "badgeLabel": "/dantalion/ demo",
+    "localeCurrentBadge": "Current",
+    "localeMenuLabel": "Select language",
+    "metaTitle": "Dantalion - birthday personality demo",
+    "summary": "Enter a birthday to render the localized personality result with the published dantalion packages.",
+    "themeToggleLabel": "Toggle light or dark theme",
+    "title": "Dantalion birthday personality demo"
+  },
+  "personalityForm": {
+    "birthdayLabel": "Birthday",
+    "detailLinkLabel": "Open detail page",
+    "emptyStateBody": "Pick a birthday inside the supported range and submit to render the localized personality result.",
+    "emptyStateTitle": "Result preview",
+    "invalidRangeMessage": "Please pick a date between 1873-02-01 and 2050-12-31.",
+    "loadingLabel": "Loading personality...",
+    "resetLabel": "Reset",
+    "resultTitle": "Personality result",
+    "submitLabel": "Show personality",
+    "supportedRangeLabel": "Supported range: 1873-02-01 to 2050-12-31"
+  },
+  "geniusPage": {
+    "breadcrumbHomeLabel": "Home",
+    "ctaLabel": "Find your genius",
+    "loadingLabel": "Loading detail page...",
+    "metaTitlePrefix": "Dantalion - ",
+    "summary": "Explore the full localized profile for this genius type.",
+    "titlePrefix": "Genius "
+  },
+  "notFoundPage": {
+    "actionLabel": "Back to the demo",
+    "body": "The page you requested is not part of this static demo build.",
+    "metaTitle": "Dantalion - Page not found",
+    "title": "Page not found"
+  }
+}

--- a/packages/web/src/i18n/locales/ja.json
+++ b/packages/web/src/i18n/locales/ja.json
@@ -1,0 +1,37 @@
+{
+  "demoPage": {
+    "badgeLabel": "/dantalion/ デモ",
+    "localeCurrentBadge": "現在",
+    "localeMenuLabel": "言語を選択",
+    "metaTitle": "Dantalion - 誕生日性格診断デモ",
+    "summary": "誕生日を入力すると、公開済みの dantalion パッケージでローカライズされた性格結果を表示します。",
+    "themeToggleLabel": "ライトテーマとダークテーマを切り替える",
+    "title": "Dantalion 誕生日性格診断デモ"
+  },
+  "personalityForm": {
+    "birthdayLabel": "誕生日",
+    "detailLinkLabel": "詳細ページを開く",
+    "emptyStateBody": "対応範囲内の誕生日を選んで送信すると、ローカライズ済みの性格結果を表示します。",
+    "emptyStateTitle": "結果プレビュー",
+    "invalidRangeMessage": "1873-02-01 から 2050-12-31 の範囲で日付を選択してください。",
+    "loadingLabel": "性格を読み込み中...",
+    "resetLabel": "リセット",
+    "resultTitle": "性格結果",
+    "submitLabel": "性格を見る",
+    "supportedRangeLabel": "対応範囲: 1873-02-01 から 2050-12-31"
+  },
+  "geniusPage": {
+    "breadcrumbHomeLabel": "ホーム",
+    "ctaLabel": "診断トップへ戻る",
+    "loadingLabel": "詳細を読み込み中...",
+    "metaTitlePrefix": "Dantalion - ",
+    "summary": "この genius type のローカライズ済み詳細ページです。",
+    "titlePrefix": "Genius "
+  },
+  "notFoundPage": {
+    "actionLabel": "デモのトップへ戻る",
+    "body": "指定されたページは、この静的デモの公開対象に含まれていません。",
+    "metaTitle": "Dantalion - ページが見つかりません",
+    "title": "ページが見つかりません"
+  }
+}

--- a/packages/web/src/i18n/web-copy.spec.ts
+++ b/packages/web/src/i18n/web-copy.spec.ts
@@ -1,0 +1,58 @@
+import { describe, expect, it } from 'vitest';
+import en from './locales/en.json';
+import ja from './locales/ja.json';
+import { getWebCopy, loadWebCopy } from './web-copy';
+
+const collectKeys = (value: unknown, prefix = ''): readonly string[] => {
+  if (value === null || typeof value !== 'object' || Array.isArray(value)) {
+    return [prefix];
+  }
+  const record = value as Record<string, unknown>;
+  return Object.keys(record)
+    .toSorted()
+    .flatMap((key) =>
+      collectKeys(record[key], prefix ? `${prefix}.${key}` : key),
+    );
+};
+
+describe('web-copy locale resources', () => {
+  it('en and ja expose the same key set', () => {
+    expect(collectKeys(ja)).toEqual(collectKeys(en));
+  });
+
+  it('every leaf value is a non-empty string', () => {
+    for (const resource of [en, ja]) {
+      const visit = (value: unknown): void => {
+        if (typeof value === 'string') {
+          expect(value.length).toBeGreaterThan(0);
+          return;
+        }
+        if (value && typeof value === 'object' && !Array.isArray(value)) {
+          for (const child of Object.values(value)) {
+            visit(child);
+          }
+        }
+      };
+      visit(resource);
+    }
+  });
+});
+
+describe('getWebCopy', () => {
+  it('returns the requested locale resource', () => {
+    expect(getWebCopy('en')).toBe(en);
+    expect(getWebCopy('ja')).toBe(ja);
+  });
+
+  it('falls back to en for unsupported languages', () => {
+    // @ts-expect-error — exercising the runtime fallback path
+    expect(getWebCopy('zh')).toBe(en);
+  });
+});
+
+describe('loadWebCopy', () => {
+  it('resolves the same shape as getWebCopy', async () => {
+    await expect(loadWebCopy('en')).resolves.toEqual(en);
+    await expect(loadWebCopy('ja')).resolves.toEqual(ja);
+  });
+});

--- a/packages/web/src/i18n/web-copy.ts
+++ b/packages/web/src/i18n/web-copy.ts
@@ -1,0 +1,35 @@
+import type { Accessor } from 'solid-js';
+import type { SupportedLanguage } from '../lib/dantalion';
+import { defaultLanguage } from '../lib/dantalion';
+import { useLocale } from '../lib/locale-context';
+import enResource from './locales/en.json';
+import jaResource from './locales/ja.json';
+
+export type WebCopy = typeof enResource;
+
+const eagerResources: Record<SupportedLanguage, WebCopy> = {
+  en: enResource,
+  ja: jaResource as WebCopy,
+};
+
+export const loadWebCopy = async (
+  language: SupportedLanguage,
+): Promise<WebCopy> => {
+  try {
+    const module = (await import(`./locales/${language}.json`)) as {
+      default: WebCopy;
+    };
+    return module.default;
+  } catch {
+    return enResource;
+  }
+};
+
+export const getWebCopy = (
+  language: SupportedLanguage = defaultLanguage,
+): WebCopy => eagerResources[language] ?? eagerResources[defaultLanguage];
+
+export const useWebCopy = (): Accessor<WebCopy> => {
+  const { language } = useLocale();
+  return () => getWebCopy(language());
+};

--- a/packages/web/src/lib/demo-page.ts
+++ b/packages/web/src/lib/demo-page.ts
@@ -1,3 +1,4 @@
+import { getWebCopy } from '../i18n/web-copy';
 import type { SupportedLanguage } from './dantalion';
 import { defaultLanguage } from './dantalion';
 
@@ -11,29 +12,6 @@ export type DemoPageCopy = {
   title: string;
 };
 
-const demoPageCopy: Record<SupportedLanguage, DemoPageCopy> = {
-  en: {
-    badgeLabel: '/dantalion/ demo',
-    localeCurrentBadge: 'Current',
-    localeMenuLabel: 'Select language',
-    metaTitle: 'Dantalion - birthday personality demo',
-    summary:
-      'Enter a birthday to render the localized personality result with the published dantalion packages.',
-    themeToggleLabel: 'Toggle light or dark theme',
-    title: 'Dantalion birthday personality demo',
-  },
-  ja: {
-    badgeLabel: '/dantalion/ デモ',
-    localeCurrentBadge: '現在',
-    localeMenuLabel: '言語を選択',
-    metaTitle: 'Dantalion - 誕生日性格診断デモ',
-    summary:
-      '誕生日を入力すると、公開済みの dantalion パッケージでローカライズされた性格結果を表示します。',
-    themeToggleLabel: 'ライトテーマとダークテーマを切り替える',
-    title: 'Dantalion 誕生日性格診断デモ',
-  },
-};
-
 export const getDemoPageCopy = (
   language: SupportedLanguage = defaultLanguage,
-): DemoPageCopy => demoPageCopy[language] ?? demoPageCopy[defaultLanguage];
+): DemoPageCopy => getWebCopy(language).demoPage;

--- a/packages/web/src/lib/genius-page.ts
+++ b/packages/web/src/lib/genius-page.ts
@@ -1,3 +1,4 @@
+import { getWebCopy } from '../i18n/web-copy';
 import type { Genius, SupportedLanguage } from './dantalion';
 import { defaultLanguage } from './dantalion';
 
@@ -17,57 +18,22 @@ export type NotFoundPageCopy = {
   title: string;
 };
 
-const getGeniusTitle = (genius: Genius): string => `Genius ${genius}`;
-
-const geniusPageCopyByLanguage: Record<
-  SupportedLanguage,
-  (genius: Genius) => GeniusPageCopy
-> = {
-  en: (genius) => ({
-    breadcrumbHomeLabel: 'Home',
-    ctaLabel: 'Find your genius',
-    loadingLabel: 'Loading detail page...',
-    metaTitle: `Dantalion - ${getGeniusTitle(genius)}`,
-    summary: 'Explore the full localized profile for this genius type.',
-    title: getGeniusTitle(genius),
-  }),
-  ja: (genius) => ({
-    breadcrumbHomeLabel: 'ホーム',
-    ctaLabel: '診断トップへ戻る',
-    loadingLabel: '詳細を読み込み中...',
-    metaTitle: `Dantalion - ${getGeniusTitle(genius)}`,
-    summary: 'この genius type のローカライズ済み詳細ページです。',
-    title: getGeniusTitle(genius),
-  }),
-};
-
-const notFoundPageCopyByLanguage: Record<SupportedLanguage, NotFoundPageCopy> =
-  {
-    en: {
-      actionLabel: 'Back to the demo',
-      body: 'The page you requested is not part of this static demo build.',
-      metaTitle: 'Dantalion - Page not found',
-      title: 'Page not found',
-    },
-    ja: {
-      actionLabel: 'デモのトップへ戻る',
-      body: '指定されたページは、この静的デモの公開対象に含まれていません。',
-      metaTitle: 'Dantalion - ページが見つかりません',
-      title: 'ページが見つかりません',
-    },
-  };
-
 export const getGeniusPageCopy = (
   language: SupportedLanguage = defaultLanguage,
   genius: Genius,
-): GeniusPageCopy =>
-  (
-    geniusPageCopyByLanguage[language] ??
-    geniusPageCopyByLanguage[defaultLanguage]
-  )(genius);
+): GeniusPageCopy => {
+  const base = getWebCopy(language).geniusPage;
+  const title = `${base.titlePrefix}${genius}`;
+  return {
+    breadcrumbHomeLabel: base.breadcrumbHomeLabel,
+    ctaLabel: base.ctaLabel,
+    loadingLabel: base.loadingLabel,
+    metaTitle: `${base.metaTitlePrefix}${title}`,
+    summary: base.summary,
+    title,
+  };
+};
 
 export const getNotFoundPageCopy = (
   language: SupportedLanguage = defaultLanguage,
-): NotFoundPageCopy =>
-  notFoundPageCopyByLanguage[language] ??
-  notFoundPageCopyByLanguage[defaultLanguage];
+): NotFoundPageCopy => getWebCopy(language).notFoundPage;

--- a/packages/web/src/lib/personality-form.ts
+++ b/packages/web/src/lib/personality-form.ts
@@ -1,3 +1,4 @@
+import { getWebCopy } from '../i18n/web-copy';
 import { defaultLanguage, type SupportedLanguage } from './dantalion';
 
 export const minBirthdayValue = '1873-02-01';
@@ -17,41 +18,9 @@ export type PersonalityFormCopy = {
   supportedRangeLabel: string;
 };
 
-const personalityFormCopy: Record<SupportedLanguage, PersonalityFormCopy> = {
-  en: {
-    birthdayLabel: 'Birthday',
-    detailLinkLabel: 'Open detail page',
-    emptyStateBody:
-      'Pick a birthday inside the supported range and submit to render the localized personality result.',
-    emptyStateTitle: 'Result preview',
-    invalidRangeMessage:
-      'Please pick a date between 1873-02-01 and 2050-12-31.',
-    loadingLabel: 'Loading personality...',
-    resetLabel: 'Reset',
-    resultTitle: 'Personality result',
-    submitLabel: 'Show personality',
-    supportedRangeLabel: `Supported range: ${minBirthdayValue} to ${maxBirthdayValue}`,
-  },
-  ja: {
-    birthdayLabel: '誕生日',
-    detailLinkLabel: '詳細ページを開く',
-    emptyStateBody:
-      '対応範囲内の誕生日を選んで送信すると、ローカライズ済みの性格結果を表示します。',
-    emptyStateTitle: '結果プレビュー',
-    invalidRangeMessage:
-      '1873-02-01 から 2050-12-31 の範囲で日付を選択してください。',
-    loadingLabel: '性格を読み込み中...',
-    resetLabel: 'リセット',
-    resultTitle: '性格結果',
-    submitLabel: '性格を見る',
-    supportedRangeLabel: `対応範囲: ${minBirthdayValue} から ${maxBirthdayValue}`,
-  },
-};
-
 export const getPersonalityFormCopy = (
   language: SupportedLanguage = defaultLanguage,
-): PersonalityFormCopy =>
-  personalityFormCopy[language] ?? personalityFormCopy[defaultLanguage];
+): PersonalityFormCopy => getWebCopy(language).personalityForm;
 
 export const parseBirthdayValue = (value: string): Date | null => {
   const match = /^(\d{4})-(\d{2})-(\d{2})$/.exec(value);


### PR DESCRIPTION
## Summary

Consolidate the existing per-locale TypeScript copy dictionaries into
JSON resources under `packages/web/src/i18n/locales/{en,ja}.json` and
add a `web-copy.ts` module exposing `WebCopy`, `loadWebCopy`,
`getWebCopy`, and `useWebCopy`. Existing getters become thin wrappers
so component call-sites are unchanged — pure refactor with zero
visible behaviour change.

Implements #32.

## What landed

- `packages/web/src/i18n/locales/en.json`, `ja.json` — full extracted copy nested under `demoPage`, `personalityForm`, `geniusPage`, `notFoundPage`
- `packages/web/src/i18n/web-copy.ts`:
  - `type WebCopy = typeof import('./locales/en.json')`
  - `loadWebCopy(language): Promise<WebCopy>` — Promise-based loader with en fallback
  - `getWebCopy(language): WebCopy` — sync accessor for SSG paths
  - `useWebCopy(): Accessor<WebCopy>` — Solid signal driven by `LocaleContext`
- `packages/web/src/i18n/web-copy.spec.ts` — en/ja key parity, non-empty leaf check, smoke test for `loadWebCopy`
- `packages/web/src/lib/demo-page.ts`, `genius-page.ts`, `personality-form.ts` — string dictionaries removed; getters reduced to thin wrappers around `getWebCopy(language)`

## Behaviour parity

- Component sites (`personality-form.tsx`, `theme-toggle.tsx`, `language-switcher.tsx`, `demo-shell.tsx`, `genius-detail-page.tsx`, all routes) continue to call the same getter functions and receive the same string shape.
- `getGeniusPageCopy(language, genius)` keeps composing the genius-specific `title` / `metaTitle` strings from the new `titlePrefix` and `metaTitlePrefix` keys.
- Existing component / route tests pass unchanged.

## Test plan

- [x] `pnpm install` resolves
- [x] `pnpm run lint` exits zero
- [x] `pnpm run test` exits zero — new `web-copy.spec.ts` passes alongside the existing suites
- [x] `pnpm --filter @kurone-kito/dantalion-web-demo-web run build` succeeds; 42 SSG routes prerender as before
- [ ] CI matrix green — verified post-merge

Closes #32

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added Japanese language support for demo pages, personality forms, and genius detail pages

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/kurone-kito/dantalion-web-demo/pull/44?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->