### PR TITLE
feat(web): nickname input + personalized result heading

### DIFF
--- a/packages/web/src/components/personality-form.tsx
+++ b/packages/web/src/components/personality-form.tsx
@@ -1,9 +1,11 @@
 import { createMemo, createResource, createSignal, Show } from 'solid-js';
+import { useWebCopy } from '../i18n/web-copy';
 import {
   getGeniusPath,
   getLocalizedPersonalityPreview,
   type LocalizedPersonalityPreview,
 } from '../lib/dantalion';
+import { formatHeading, normalizeNickname } from '../lib/heading';
 import { useLocale } from '../lib/locale-context';
 import {
   defaultBirthdayValue,
@@ -15,12 +17,14 @@ import {
 } from '../lib/personality-form';
 
 const minimumLoadingMs = 150;
+const nicknameMaxLength = 32;
 
 export type PersonalityFormProps = {
   loadPersonality?: PersonalityLoader;
 };
 
 type Submission = {
+  nickname: string | undefined;
   nonce: number;
   value: string;
 };
@@ -37,11 +41,13 @@ export type PersonalityLoader = (
 export function PersonalityForm(props: PersonalityFormProps) {
   const { language } = useLocale();
   const copy = createMemo(() => getPersonalityFormCopy(language()));
+  const webCopy = useWebCopy();
   const loadPersonality = () =>
     props.loadPersonality ??
     ((birthday: Date) => getLocalizedPersonalityPreview(birthday, language()));
 
   const [dateValue, setDateValue] = createSignal(defaultBirthdayValue);
+  const [nicknameValue, setNicknameValue] = createSignal('');
   const [submission, setSubmission] = createSignal<Submission>();
   const [result, { mutate }] = createResource(submission, async (request) => {
     const birthday = parseBirthdayValue(request.value);
@@ -69,14 +75,31 @@ export function PersonalityForm(props: PersonalityFormProps) {
       return;
     }
 
-    setSubmission({ nonce: Date.now(), value: dateValue() });
+    setSubmission({
+      nickname: normalizeNickname(nicknameValue(), nicknameMaxLength),
+      nonce: Date.now(),
+      value: dateValue(),
+    });
   };
 
   const handleReset = () => {
     setDateValue(defaultBirthdayValue);
+    setNicknameValue('');
     setSubmission(undefined);
     mutate(undefined);
   };
+
+  const personalizedHeading = createMemo(() => {
+    const current = submission();
+    if (!current) {
+      return copy().resultTitle;
+    }
+    return formatHeading(
+      webCopy().result.headingTemplate,
+      current.nickname,
+      webCopy().result.nicknameFallback,
+    );
+  });
 
   return (
     <section class="grid gap-6 lg:grid-cols-[minmax(0,24rem)_minmax(0,1fr)]">
@@ -103,6 +126,29 @@ export function PersonalityForm(props: PersonalityFormProps) {
             </label>
             <p class="text-sm text-base-content/70" id="birthday-help">
               {copy().supportedRangeLabel}
+            </p>
+
+            <label class="form-control gap-2" for="nickname">
+              <span class="label-text text-sm font-medium">
+                {copy().nicknameLabel}
+              </span>
+              <input
+                aria-describedby="nickname-help"
+                autocomplete="nickname"
+                class="input input-bordered w-full"
+                id="nickname"
+                maxlength={nicknameMaxLength}
+                name="nickname"
+                onInput={(event) => {
+                  setNicknameValue(event.currentTarget.value);
+                }}
+                placeholder={copy().nicknamePlaceholder}
+                type="text"
+                value={nicknameValue()}
+              />
+            </label>
+            <p class="text-sm text-base-content/70" id="nickname-help">
+              {copy().nicknameHelp}
             </p>
 
             <Show when={validationMessage()}>
@@ -134,7 +180,7 @@ export function PersonalityForm(props: PersonalityFormProps) {
         <div aria-live="polite" class="card-body gap-5">
           <div class="flex items-center justify-between gap-3">
             <div>
-              <h2 class="card-title text-2xl">{copy().resultTitle}</h2>
+              <h2 class="card-title text-2xl">{personalizedHeading()}</h2>
               <p class="text-sm text-base-content/70">
                 {copy().emptyStateBody}
               </p>

--- a/packages/web/src/i18n/locales/en.json
+++ b/packages/web/src/i18n/locales/en.json
@@ -15,10 +15,17 @@
     "emptyStateTitle": "Result preview",
     "invalidRangeMessage": "Please pick a date between 1873-02-01 and 2050-12-31.",
     "loadingLabel": "Loading personality...",
+    "nicknameHelp": "Used only inside this tab to personalize the result heading.",
+    "nicknameLabel": "Nickname (optional)",
+    "nicknamePlaceholder": "Your name or alias",
     "resetLabel": "Reset",
     "resultTitle": "Personality result",
     "submitLabel": "Show personality",
     "supportedRangeLabel": "Supported range: 1873-02-01 to 2050-12-31"
+  },
+  "result": {
+    "headingTemplate": "{{nickname}}'s personality",
+    "nicknameFallback": "Anonymous"
   },
   "geniusPage": {
     "breadcrumbHomeLabel": "Home",

--- a/packages/web/src/i18n/locales/ja.json
+++ b/packages/web/src/i18n/locales/ja.json
@@ -15,10 +15,17 @@
     "emptyStateTitle": "結果プレビュー",
     "invalidRangeMessage": "1873-02-01 から 2050-12-31 の範囲で日付を選択してください。",
     "loadingLabel": "性格を読み込み中...",
+    "nicknameHelp": "このタブの中でのみ使用し、結果の見出しを個別表示するために用います。",
+    "nicknameLabel": "ニックネーム (任意)",
+    "nicknamePlaceholder": "名前またはエイリアス",
     "resetLabel": "リセット",
     "resultTitle": "性格結果",
     "submitLabel": "性格を見る",
     "supportedRangeLabel": "対応範囲: 1873-02-01 から 2050-12-31"
+  },
+  "result": {
+    "headingTemplate": "{{nickname}}さんの性格診断",
+    "nicknameFallback": "名無しの権兵衛"
   },
   "geniusPage": {
     "breadcrumbHomeLabel": "ホーム",

--- a/packages/web/src/lib/heading.spec.ts
+++ b/packages/web/src/lib/heading.spec.ts
@@ -1,0 +1,59 @@
+import { describe, expect, it } from 'vitest';
+import { formatHeading, normalizeNickname } from './heading';
+
+describe('formatHeading', () => {
+  it('substitutes the nickname token with the trimmed value', () => {
+    expect(
+      formatHeading("{{nickname}}'s personality", 'Alice', 'Anonymous'),
+    ).toBe("Alice's personality");
+  });
+
+  it('falls back when nickname is undefined', () => {
+    expect(
+      formatHeading('{{nickname}}さんの性格診断', undefined, '名無しの権兵衛'),
+    ).toBe('名無しの権兵衛さんの性格診断');
+  });
+
+  it('falls back when nickname is empty or whitespace', () => {
+    expect(formatHeading('{{nickname}} result', '', 'Anon')).toBe(
+      'Anon result',
+    );
+    expect(formatHeading('{{nickname}} result', '   ', 'Anon')).toBe(
+      'Anon result',
+    );
+  });
+
+  it('leaves templates without the token untouched', () => {
+    expect(formatHeading('Personality result', 'Bob', 'Anon')).toBe(
+      'Personality result',
+    );
+  });
+
+  it('replaces every occurrence of the nickname token', () => {
+    expect(
+      formatHeading('{{nickname}}, see {{nickname}} again', 'Bob', 'Anon'),
+    ).toBe('Bob, see Bob again');
+  });
+});
+
+describe('normalizeNickname', () => {
+  it('returns undefined for empty / whitespace-only / non-string inputs', () => {
+    expect(normalizeNickname(undefined)).toBeUndefined();
+    expect(normalizeNickname(null)).toBeUndefined();
+    expect(normalizeNickname('')).toBeUndefined();
+    expect(normalizeNickname('   ')).toBeUndefined();
+  });
+
+  it('trims surrounding whitespace', () => {
+    expect(normalizeNickname('  Alice  ')).toBe('Alice');
+  });
+
+  it('truncates to the configured maximum length', () => {
+    const overlong = 'a'.repeat(40);
+    expect(normalizeNickname(overlong, 32)).toBe('a'.repeat(32));
+  });
+
+  it('keeps strings inside the maximum length intact', () => {
+    expect(normalizeNickname('Bob', 32)).toBe('Bob');
+  });
+});

--- a/packages/web/src/lib/heading.ts
+++ b/packages/web/src/lib/heading.ts
@@ -1,0 +1,23 @@
+export const formatHeading = (
+  template: string,
+  nickname: string | undefined,
+  fallback: string,
+): string => {
+  const trimmed = nickname?.trim();
+  const name = trimmed && trimmed.length > 0 ? trimmed : fallback;
+  return template.replaceAll('{{nickname}}', name);
+};
+
+export const normalizeNickname = (
+  value: string | null | undefined,
+  maxLength = 32,
+): string | undefined => {
+  if (typeof value !== 'string') {
+    return undefined;
+  }
+  const trimmed = value.trim();
+  if (trimmed.length === 0) {
+    return undefined;
+  }
+  return trimmed.length > maxLength ? trimmed.slice(0, maxLength) : trimmed;
+};

--- a/packages/web/src/lib/personality-form.ts
+++ b/packages/web/src/lib/personality-form.ts
@@ -12,6 +12,9 @@ export type PersonalityFormCopy = {
   emptyStateTitle: string;
   invalidRangeMessage: string;
   loadingLabel: string;
+  nicknameHelp: string;
+  nicknameLabel: string;
+  nicknamePlaceholder: string;
   resetLabel: string;
   resultTitle: string;
   submitLabel: string;


### PR DESCRIPTION
## Summary

Add an optional nickname field that personalizes the result heading via
a `formatHeading({{nickname}} template, nickname, fallback)` helper.
The nickname stays in-memory only — no `localStorage`, no URL state in
this issue (that ships separately via #37 once permalink semantics are
decided).

Implements #34.

## What landed

- `packages/web/src/lib/heading.ts` — `formatHeading` and
  `normalizeNickname` (trim + 32-char cap)
- `packages/web/src/lib/heading.spec.ts` — substitution, fallback,
  whitespace, multi-occurrence, max-length cases
- `packages/web/src/i18n/locales/{en,ja}.json` — adds
  `personalityForm.nickname{Label,Help,Placeholder}` and
  `result.{headingTemplate,nicknameFallback}` keys (en uses
  `"{{nickname}}'s personality"` / `"Anonymous"`; ja uses
  `"{{nickname}}さんの性格診断"` / `"名無しの権兵衛"` for v0.19.1 parity)
- `packages/web/src/lib/personality-form.ts` — extends
  `PersonalityFormCopy` type with the three new nickname keys
- `packages/web/src/components/personality-form.tsx` — second input
  with `aria-describedby="nickname-help"`, helper text, max-length 32;
  submit handler captures the normalized nickname; result heading
  reactively re-renders via `formatHeading` after each submit

## Test plan

- [x] Empty nickname → result heading uses the locale fallback
      (`Anonymous` / `名無しの権兵衛`)
- [x] Nickname "Alice" → heading shows `Alice's personality`
- [x] Whitespace-only nickname falls back to the placeholder
- [x] Switching language after submit refreshes the rendered heading
      to the active locale's template
- [x] `pnpm run lint` exits zero
- [x] `pnpm run test` exits zero (new `heading.spec.ts` + existing
      suites green)
- [x] `pnpm --filter @kurone-kito/dantalion-web-demo-web run build`
      succeeds; 42 SSG routes prerender as before
- [ ] CI matrix green — verified post-merge

Closes #34

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added nickname input field to the personality form with validation and character limits.
  * Result headings now dynamically display the submitted nickname with a fallback option.

* **Tests**
  * Added test coverage for heading formatting and nickname normalization utilities.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/kurone-kito/dantalion-web-demo/pull/45?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->