### PR TITLE
feat(web): library landing section

### DIFF
--- a/packages/web/src/components/landing/feature-section.tsx
+++ b/packages/web/src/components/landing/feature-section.tsx
@@ -1,0 +1,34 @@
+import { For } from 'solid-js';
+import { useWebCopy } from '../../i18n/web-copy';
+import { renderMarkdownToHtml } from '../../lib/dantalion';
+
+export function FeatureSection() {
+  const copy = useWebCopy();
+  return (
+    <section
+      aria-labelledby="feature-heading"
+      class="card bg-base-100 shadow-xl"
+    >
+      <div class="card-body gap-4">
+        <h2 class="card-title text-2xl" id="feature-heading">
+          {copy().landing.feature.title}
+        </h2>
+        <ul class="grid gap-2 text-base-content">
+          <For each={copy().landing.feature.items}>
+            {(item) => (
+              <li class="flex items-start gap-2">
+                <span aria-hidden="true" class="mt-1 text-primary">
+                  ✓
+                </span>
+                <span
+                  class="prose max-w-none flex-1"
+                  innerHTML={renderMarkdownToHtml(item)}
+                />
+              </li>
+            )}
+          </For>
+        </ul>
+      </div>
+    </section>
+  );
+}

--- a/packages/web/src/components/landing/hero-section.tsx
+++ b/packages/web/src/components/landing/hero-section.tsx
@@ -1,0 +1,24 @@
+import { useWebCopy } from '../../i18n/web-copy';
+
+export function HeroSection() {
+  const copy = useWebCopy();
+  return (
+    <section
+      aria-label={copy().demoPage.title}
+      class="hero rounded-box bg-base-100 shadow-xl"
+    >
+      <div class="hero-content flex-col items-start gap-3 text-left">
+        <span class="badge badge-primary badge-lg">
+          {copy().demoPage.badgeLabel}
+        </span>
+        <h1 class="text-4xl font-bold">{copy().demoPage.title}</h1>
+        <p class="max-w-3xl text-lg text-base-content/80">
+          {copy().landing.hero.tagline}
+        </p>
+        <p class="max-w-3xl text-sm text-base-content/70">
+          {copy().landing.hero.subtitle}
+        </p>
+      </div>
+    </section>
+  );
+}

--- a/packages/web/src/components/landing/install-section.tsx
+++ b/packages/web/src/components/landing/install-section.tsx
@@ -1,0 +1,79 @@
+import { createSignal, Show } from 'solid-js';
+import { useWebCopy } from '../../i18n/web-copy';
+
+type CopyableCodeBlockProps = {
+  buttonLabel: string;
+  code: string;
+  confirmationLabel: string;
+  heading: string;
+};
+
+function CopyableCodeBlock(props: CopyableCodeBlockProps) {
+  const [copied, setCopied] = createSignal(false);
+  const handleCopy = async () => {
+    try {
+      await navigator.clipboard.writeText(props.code);
+      setCopied(true);
+      window.setTimeout(() => setCopied(false), 2500);
+    } catch {
+      // ignore clipboard write failures — the code block stays selectable
+    }
+  };
+  return (
+    <article class="rounded-box border border-base-300 bg-base-200 p-4">
+      <header class="mb-3 flex items-center justify-between gap-3">
+        <h3 class="font-semibold">{props.heading}</h3>
+        <button
+          class="btn btn-outline btn-sm"
+          onClick={handleCopy}
+          type="button"
+        >
+          {props.buttonLabel}
+        </button>
+      </header>
+      <pre class="overflow-x-auto rounded-box bg-base-300 p-3 text-sm leading-relaxed text-base-content">
+        <code>{props.code}</code>
+      </pre>
+      <Show when={copied()}>
+        <p aria-live="polite" class="mt-2 text-xs text-success">
+          {props.confirmationLabel}
+        </p>
+      </Show>
+    </article>
+  );
+}
+
+export function InstallSection() {
+  const copy = useWebCopy();
+  return (
+    <section
+      aria-labelledby="install-heading"
+      class="card bg-base-100 shadow-xl"
+    >
+      <div class="card-body gap-4">
+        <div class="space-y-1">
+          <h2 class="card-title text-2xl" id="install-heading">
+            {copy().landing.install.title}
+          </h2>
+          <p class="text-sm text-base-content/70">
+            {copy().landing.install.subtitle}
+          </p>
+        </div>
+        <div class="grid gap-4 lg:grid-cols-2">
+          <CopyableCodeBlock
+            buttonLabel={copy().landing.install.copyButtonLabel}
+            code={copy().landing.install.cliCode}
+            confirmationLabel={copy().landing.install.copyConfirmation}
+            heading={copy().landing.install.cliHeading}
+          />
+          <CopyableCodeBlock
+            buttonLabel={copy().landing.install.copyButtonLabel}
+            code={copy().landing.install.libraryCode}
+            confirmationLabel={copy().landing.install.copyConfirmation}
+            heading={copy().landing.install.libraryHeading}
+          />
+        </div>
+      </div>
+    </section>
+  );
+}

--- a/packages/web/src/components/landing/preface-section.tsx
+++ b/packages/web/src/components/landing/preface-section.tsx
@@ -1,0 +1,33 @@
+import { createMemo } from 'solid-js';
+import { useWebCopy } from '../../i18n/web-copy';
+import { renderMarkdownToHtml } from '../../lib/dantalion';
+
+export function PrefaceSection() {
+  const copy = useWebCopy();
+  const introHtml = createMemo(() =>
+    renderMarkdownToHtml(copy().landing.preface.intro),
+  );
+  const purposeHtml = createMemo(() =>
+    renderMarkdownToHtml(copy().landing.preface.purpose),
+  );
+  return (
+    <section
+      aria-labelledby="preface-heading"
+      class="card bg-base-100 shadow-xl"
+    >
+      <div class="card-body gap-3">
+        <h2 class="card-title text-2xl" id="preface-heading">
+          {copy().demoPage.title}
+        </h2>
+        <div
+          class="prose max-w-none text-base-content"
+          innerHTML={introHtml()}
+        />
+        <div
+          class="prose max-w-none text-base-content"
+          innerHTML={purposeHtml()}
+        />
+      </div>
+    </section>
+  );
+}

--- a/packages/web/src/components/landing/privacy-callout.tsx
+++ b/packages/web/src/components/landing/privacy-callout.tsx
@@ -1,0 +1,22 @@
+import { useWebCopy } from '../../i18n/web-copy';
+
+export function PrivacyCallout() {
+  const copy = useWebCopy();
+  return (
+    <aside
+      aria-labelledby="privacy-callout-heading"
+      class="alert alert-info"
+      role="note"
+    >
+      <div class="flex flex-col items-start gap-1 text-left">
+        <h3
+          class="text-base font-semibold uppercase"
+          id="privacy-callout-heading"
+        >
+          {copy().landing.privacy.title}
+        </h3>
+        <p class="text-sm">{copy().landing.privacy.body}</p>
+      </div>
+    </aside>
+  );
+}

--- a/packages/web/src/components/landing/repo-cta.tsx
+++ b/packages/web/src/components/landing/repo-cta.tsx
@@ -1,0 +1,30 @@
+import { useWebCopy } from '../../i18n/web-copy';
+
+export function RepoCta() {
+  const copy = useWebCopy();
+  return (
+    <section
+      aria-labelledby="repo-cta-heading"
+      class="card bg-base-100 shadow-xl"
+    >
+      <div class="card-body items-start gap-3 lg:flex-row lg:items-center lg:justify-between">
+        <div class="space-y-1">
+          <h2 class="card-title text-2xl" id="repo-cta-heading">
+            {copy().landing.repo.cta}
+          </h2>
+          <p class="text-sm text-base-content/70">
+            {copy().landing.repo.subtitle}
+          </p>
+        </div>
+        <a
+          class="btn btn-secondary btn-lg"
+          href={copy().landing.repo.href}
+          rel="noreferrer noopener"
+          target="_blank"
+        >
+          GitHub →
+        </a>
+      </div>
+    </section>
+  );
+}

--- a/packages/web/src/i18n/locales/en.json
+++ b/packages/web/src/i18n/locales/en.json
@@ -23,6 +23,45 @@
     "submitLabel": "Show personality",
     "supportedRangeLabel": "Supported range: 1873-02-01 to 2050-12-31"
   },
+  "landing": {
+    "feature": {
+      "items": [
+        "Supports birthdays from 1873-02-01 through 2050-12-31.",
+        "Calculation and localized copy ship as separate packages so the CLI, web demo, and your own apps can reuse the same core.",
+        "Pure ESM modules targeting Node `^22.22.2 || >=24`, ready to bundle for modern browsers.",
+        "Ships TypeScript declarations alongside the runtime artifacts.",
+        "Available as both an installable CLI (`@kurone-kito/dantalion-cli`) and an embeddable library (`@kurone-kito/dantalion-core`)."
+      ],
+      "title": "Library highlights"
+    },
+    "hero": {
+      "subtitle": "Powered by the open-source dantalion library.",
+      "tagline": "Birthday-to-personality, in the browser."
+    },
+    "install": {
+      "cliCode": "npm install --global @kurone-kito/dantalion-cli\ndantalion personality 2000-01-01\ndantalion --help",
+      "cliHeading": "CLI",
+      "copyButtonLabel": "Copy",
+      "copyConfirmation": "Copied to clipboard",
+      "libraryCode": "npm install --save @kurone-kito/dantalion-core @kurone-kito/dantalion-i18n",
+      "libraryHeading": "As a library",
+      "subtitle": "Install the published dantalion packages on the `next` dist-tag for the modernized `v1.0.0-rc.x` line.",
+      "title": "Install"
+    },
+    "preface": {
+      "intro": "“Dantalion” is the seventy-first demon in [the Lesser Key of Solomon](https://en.wikipedia.org/wiki/The_Lesser_Key_of_Solomon). He teaches every kind of academic knowledge but also reads and steers the will of others.",
+      "purpose": "This site is a thin browser demo of `@kurone-kito/dantalion-core` and `@kurone-kito/dantalion-i18n`. Pick a birthday and the libraries compute the personality details client-side, then localize the rendered narrative in your language."
+    },
+    "privacy": {
+      "body": "Your birthday is processed entirely in this browser tab. Nothing is sent to a server, nothing is persisted off-device.",
+      "title": "Privacy"
+    },
+    "repo": {
+      "cta": "See the library on GitHub",
+      "href": "https://github.com/kurone-kito/dantalion",
+      "subtitle": "Open the source, file issues, or read the documentation."
+    }
+  },
   "result": {
     "headingTemplate": "{{nickname}}'s personality",
     "nicknameFallback": "Anonymous"

--- a/packages/web/src/i18n/locales/ja.json
+++ b/packages/web/src/i18n/locales/ja.json
@@ -23,6 +23,45 @@
     "submitLabel": "性格を見る",
     "supportedRangeLabel": "対応範囲: 1873-02-01 から 2050-12-31"
   },
+  "landing": {
+    "feature": {
+      "items": [
+        "1873 年 2 月 1 日から 2050 年 12 月 31 日までの誕生日に対応します。",
+        "計算ロジックとローカライズ文言は別パッケージなので、CLI / Web デモ / あなたの自作アプリ間で同じコアを使い回せます。",
+        "Pure ESM モジュールで Node `^22.22.2 || >=24` を対象、モダンブラウザー向けのバンドルにそのまま組み込めます。",
+        "実行時バイナリと一緒に TypeScript 型定義も同梱しています。",
+        "CLI 版 (`@kurone-kito/dantalion-cli`) と組み込みライブラリ版 (`@kurone-kito/dantalion-core`) のどちらでも利用できます。"
+      ],
+      "title": "ライブラリの特徴"
+    },
+    "hero": {
+      "subtitle": "オープンソース dantalion ライブラリで稼働しています。",
+      "tagline": "誕生日から性格を、ブラウザーで。"
+    },
+    "install": {
+      "cliCode": "npm install --global @kurone-kito/dantalion-cli\ndantalion personality 2000-01-01\ndantalion --help",
+      "cliHeading": "CLI",
+      "copyButtonLabel": "コピー",
+      "copyConfirmation": "クリップボードにコピーしました",
+      "libraryCode": "npm install --save @kurone-kito/dantalion-core @kurone-kito/dantalion-i18n",
+      "libraryHeading": "ライブラリとして使用",
+      "subtitle": "モダン化された `v1.0.0-rc.x` ラインに対応する `next` dist-tag から、公開済みの dantalion パッケージをインストールします。",
+      "title": "インストール"
+    },
+    "preface": {
+      "intro": "“ダンタリオン”は、[ソロモンの鍵](https://ja.wikipedia.org/wiki/%E3%82%BD%E3%83%AD%E3%83%A2%E3%83%B3%E3%81%AE%E5%B0%8F%E9%8D%B5) に登場する 71 番目の悪魔です。あらゆる学術知識を教える一方で、人の心を読み取り意のままに操る力を持っているとされています。",
+      "purpose": "このサイトは `@kurone-kito/dantalion-core` と `@kurone-kito/dantalion-i18n` の薄いブラウザーデモです。誕生日を選ぶとライブラリがクライアント上で性格を計算し、結果をあなたの言語にローカライズしてレンダリングします。"
+    },
+    "privacy": {
+      "body": "誕生日はこのブラウザータブの中だけで処理されます。サーバーへの送信や端末外への永続化は一切ありません。",
+      "title": "プライバシー"
+    },
+    "repo": {
+      "cta": "ライブラリの GitHub リポジトリを開く",
+      "href": "https://github.com/kurone-kito/dantalion",
+      "subtitle": "ソース閲覧、issue 報告、ドキュメント参照はこちらから。"
+    }
+  },
   "result": {
     "headingTemplate": "{{nickname}}さんの性格診断",
     "nicknameFallback": "名無しの権兵衛"

--- a/packages/web/src/routes/[lang]/index.tsx
+++ b/packages/web/src/routes/[lang]/index.tsx
@@ -1,3 +1,9 @@
+import { FeatureSection } from '../../components/landing/feature-section';
+import { HeroSection } from '../../components/landing/hero-section';
+import { InstallSection } from '../../components/landing/install-section';
+import { PrefaceSection } from '../../components/landing/preface-section';
+import { PrivacyCallout } from '../../components/landing/privacy-callout';
+import { RepoCta } from '../../components/landing/repo-cta';
 import { PersonalityForm } from '../../components/personality-form';
 import { RouteMeta } from '../../components/route-meta';
 import { getDemoPageCopy } from '../../lib/demo-page';
@@ -15,7 +21,13 @@ export default function LocalizedHome() {
         path={`/${language()}/`}
         title={copy().metaTitle}
       />
+      <HeroSection />
+      <PrivacyCallout />
       <PersonalityForm />
+      <PrefaceSection />
+      <FeatureSection />
+      <InstallSection />
+      <RepoCta />
     </>
   );
 }


### PR DESCRIPTION
## Summary

Restore the v0.19.1 playground's library landing content with
modernized copy and a DaisyUI-native layout. The locale-pinned home
routes now show, in order: hero → privacy callout → personality form →
preface → feature highlights → install code blocks → repo CTA.

Implements #33.

## What landed

- `packages/web/src/components/landing/` — six new components:
  - `hero-section.tsx` — DaisyUI hero with the existing demoPage
    title, badge, hero tagline + subtitle from new copy keys.
  - `preface-section.tsx` — two paragraphs (Dantalion name origin + library purpose) rendered through `renderMarkdownToHtml` so inline Wikipedia links resolve.
  - `feature-section.tsx` — `<ul>` of five library highlights (modernized for `Node ^22.22.2 || >=24` and the v1.0.0-rc.x line; dropped the v0.19.1 "今後対応予定" bullet per the v1.1 scope).
  - `install-section.tsx` — two side-by-side `<pre><code>` blocks with copy-to-clipboard buttons; ARIA-live confirmation toast that auto-clears after 2.5 s.
  - `repo-cta.tsx` — DaisyUI `btn btn-secondary btn-lg` link to `github.com/kurone-kito/dantalion`.
  - `privacy-callout.tsx` — DaisyUI `alert alert-info` placed above the form so the no-transmission promise is visible before the user types.
- `packages/web/src/i18n/locales/{en,ja}.json` — adds the `landing.*` namespace covering all six components in both locales (Japanese mirrors the v0.19.1 wording).
- `packages/web/src/routes/[lang]/index.tsx` — mounts the landing components around `PersonalityForm`.

## Routes not touched

- `/` (unprefixed) — redirects to the preferred locale on mount; landing content lives on the locale-pinned routes.
- `/<lang>/<genius>/` (per-genius detail) — stays result-only.
- `404.html` and the legacy `<genius>.html` routes — unchanged.

## Test plan

- [x] `pnpm install` resolves (no new dependencies)
- [x] `pnpm run lint` exits zero
- [x] `pnpm run test` exits zero (existing suites cover the i18n key parity which now includes the new keys)
- [x] `pnpm --filter @kurone-kito/dantalion-web-demo-web run build` succeeds; 42 SSG routes prerender
- [ ] CI matrix green — verified post-merge

Closes #33

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Redesigned landing page with hero section, feature highlights, and installation instructions
  * Added copy-to-clipboard functionality for install commands
  * Integrated privacy callout and GitHub repository link on the landing page

* **Localization**
  * Added complete English and Japanese translations for all landing page content

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/kurone-kito/dantalion-web-demo/pull/46?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->