### PR TITLE
feat(web): render the personality result as per-section cards

### DIFF
--- a/packages/web/src/components/personality-form.spec.tsx
+++ b/packages/web/src/components/personality-form.spec.tsx
@@ -19,6 +19,14 @@ describe('PersonalityForm', () => {
       async (): Promise<LocalizedPersonalityPreview> => ({
         genius: '100',
         html: '<h2>Major categories of personality</h2>',
+        introHtml: '',
+        sections: [
+          {
+            bodyHtml: '<p>Test section body</p>',
+            heading: 'Major categories of personality',
+            id: 'major-categories-of-personality',
+          },
+        ],
       }),
     );
 
@@ -78,6 +86,8 @@ describe('PersonalityForm', () => {
       async (): Promise<LocalizedPersonalityPreview> => ({
         genius: '100',
         html: '<h2>Should not render</h2>',
+        introHtml: '',
+        sections: [],
       }),
     );
 
@@ -113,6 +123,8 @@ describe('PersonalityForm', () => {
             async (): Promise<LocalizedPersonalityPreview> => ({
               genius: '100',
               html: '<h2>unused</h2>',
+              introHtml: '',
+              sections: [],
             }),
           )}
         />

--- a/packages/web/src/components/personality-form.tsx
+++ b/packages/web/src/components/personality-form.tsx
@@ -1,4 +1,4 @@
-import { createMemo, createResource, createSignal, Show } from 'solid-js';
+import { createMemo, createResource, createSignal, For, Show } from 'solid-js';
 import { useWebCopy } from '../i18n/web-copy';
 import {
   getGeniusPath,
@@ -15,6 +15,7 @@ import {
   minBirthdayValue,
   parseBirthdayValue,
 } from '../lib/personality-form';
+import { SectionCard } from './result/section-card';
 
 const minimumLoadingMs = 150;
 const nicknameMaxLength = 32;
@@ -216,9 +217,22 @@ export function PersonalityForm(props: PersonalityFormProps) {
           >
             {(preview) => (
               <div class="grid gap-4">
-                <div class="prose max-w-none rounded-box border border-base-300 bg-base-200 p-6">
-                  <div innerHTML={preview().html} />
-                </div>
+                <Show when={preview().introHtml}>
+                  {(introHtml) => (
+                    <div
+                      class="prose max-w-none rounded-box border border-base-300 bg-base-200 p-4"
+                      innerHTML={introHtml()}
+                    />
+                  )}
+                </Show>
+                <For each={preview().sections}>
+                  {(section) => (
+                    <SectionCard
+                      bodyHtml={section.bodyHtml}
+                      section={section}
+                    />
+                  )}
+                </For>
                 <div class="flex justify-end">
                   <a
                     class="btn btn-outline btn-sm"

--- a/packages/web/src/components/result/section-card.tsx
+++ b/packages/web/src/components/result/section-card.tsx
@@ -1,0 +1,22 @@
+import type { LocalizedPersonalitySection } from '../../lib/dantalion';
+
+export type SectionCardProps = {
+  bodyHtml: string;
+  section: Pick<LocalizedPersonalitySection, 'heading' | 'id'>;
+};
+
+export function SectionCard(props: SectionCardProps) {
+  return (
+    <article
+      aria-labelledby={`section-${props.section.id}`}
+      class="card bg-base-100 shadow-xl"
+    >
+      <div class="card-body gap-3">
+        <h3 class="card-title text-xl" id={`section-${props.section.id}`}>
+          {props.section.heading}
+        </h3>
+        <div class="prose max-w-none" innerHTML={props.bodyHtml} />
+      </div>
+    </article>
+  );
+}

--- a/packages/web/src/lib/dantalion.ts
+++ b/packages/web/src/lib/dantalion.ts
@@ -10,9 +10,16 @@ import {
 } from '@kurone-kito/dantalion-i18n';
 import DOMPurify from 'isomorphic-dompurify';
 import { marked } from 'marked';
+import { splitMarkdownIntoSections } from './personality-sections';
 
 export type { Genius } from '@kurone-kito/dantalion-core';
 export type { DescriptionsType };
+
+export type LocalizedPersonalitySection = {
+  bodyHtml: string;
+  heading: string;
+  id: string;
+};
 
 const supportedLanguageValues = ['en', 'ja'] as const;
 
@@ -100,6 +107,8 @@ export const getLocalizedPersonalityHtml = async (
 export type LocalizedPersonalityPreview = {
   genius: Genius;
   html: string;
+  introHtml: string;
+  sections: readonly LocalizedPersonalitySection[];
 };
 
 export const getLocalizedPersonalityPreview = async (
@@ -107,10 +116,18 @@ export const getLocalizedPersonalityPreview = async (
   language: SupportedLanguage,
 ): Promise<LocalizedPersonalityPreview> => {
   const personality = getPersonalityFor(birthday);
+  const markdown = await getLocalizedPersonalityMarkdown(birthday, language);
+  const { intro, sections } = splitMarkdownIntoSections(markdown);
 
   return {
     genius: personality.inner,
-    html: await getLocalizedPersonalityHtml(birthday, language),
+    html: renderMarkdownToHtml(markdown),
+    introHtml: intro ? renderMarkdownToHtml(intro) : '',
+    sections: sections.map((section) => ({
+      bodyHtml: renderMarkdownToHtml(section.body),
+      heading: section.heading,
+      id: section.id,
+    })),
   };
 };
 

--- a/packages/web/src/lib/personality-sections.spec.ts
+++ b/packages/web/src/lib/personality-sections.spec.ts
@@ -1,0 +1,49 @@
+import { describe, expect, it } from 'vitest';
+import { splitMarkdownIntoSections } from './personality-sections';
+
+describe('splitMarkdownIntoSections', () => {
+  it('separates ## sections', () => {
+    const markdown = [
+      '# Title',
+      '',
+      'intro paragraph',
+      '',
+      '## Section A',
+      'body of A',
+      '',
+      '## Section B',
+      'body of B',
+    ].join('\n');
+    const result = splitMarkdownIntoSections(markdown);
+    expect(result.intro).toBe('intro paragraph');
+    expect(result.sections).toHaveLength(2);
+    expect(result.sections[0]?.heading).toBe('Section A');
+    expect(result.sections[0]?.body).toBe('body of A');
+    expect(result.sections[1]?.heading).toBe('Section B');
+    expect(result.sections[1]?.body).toBe('body of B');
+  });
+
+  it('keeps the trailing section even without a sentinel', () => {
+    const markdown = '# Title\n\n## Only one\nbody';
+    const result = splitMarkdownIntoSections(markdown);
+    expect(result.sections).toHaveLength(1);
+    expect(result.sections[0]?.heading).toBe('Only one');
+    expect(result.sections[0]?.body).toBe('body');
+  });
+
+  it('returns an empty intro and no sections for empty input', () => {
+    const result = splitMarkdownIntoSections('');
+    expect(result.intro).toBe('');
+    expect(result.sections).toHaveLength(0);
+  });
+
+  it('produces stable slug ids derived from headings', () => {
+    const result = splitMarkdownIntoSections(
+      '## 性格の大分類\nbody\n\n## Personality category\nmore body',
+    );
+    expect(result.sections.map((section) => section.id)).toEqual([
+      '性格の大分類',
+      'personality-category',
+    ]);
+  });
+});

--- a/packages/web/src/lib/personality-sections.ts
+++ b/packages/web/src/lib/personality-sections.ts
@@ -1,0 +1,66 @@
+export type PersonalitySection = {
+  body: string;
+  heading: string;
+  id: string;
+};
+
+export type PersonalitySplit = {
+  intro: string;
+  sections: readonly PersonalitySection[];
+};
+
+const slugify = (heading: string): string =>
+  heading
+    .toLowerCase()
+    .normalize('NFKD')
+    .replaceAll(/[^a-z0-9\p{Letter}\p{Number}]+/gu, '-')
+    .replaceAll(/^-+|-+$/gu, '');
+
+export const splitMarkdownIntoSections = (
+  markdown: string,
+): PersonalitySplit => {
+  const lines = markdown.split('\n');
+  let intro = '';
+  const sections: PersonalitySection[] = [];
+
+  let current: { heading: string; body: string[] } | null = null;
+  const introLines: string[] = [];
+
+  for (const line of lines) {
+    const match = /^##\s+(.+?)\s*$/.exec(line);
+    if (match?.[1]) {
+      if (current) {
+        sections.push({
+          body: current.body.join('\n').trim(),
+          heading: current.heading,
+          id: slugify(current.heading),
+        });
+      }
+      current = { body: [], heading: match[1].trim() };
+      continue;
+    }
+
+    if (current) {
+      current.body.push(line);
+      continue;
+    }
+
+    if (/^#\s+/.test(line)) {
+      // skip the top-level title — the wrapper supplies its own heading
+      continue;
+    }
+    introLines.push(line);
+  }
+
+  if (current) {
+    sections.push({
+      body: current.body.join('\n').trim(),
+      heading: current.heading,
+      id: slugify(current.heading),
+    });
+  }
+
+  intro = introLines.join('\n').trim();
+
+  return { intro, sections };
+};


### PR DESCRIPTION
## Summary

Replace the single monolithic prose blob from the v1.0 cut-over with
DaisyUI cards rendered per Markdown `##` section. The personality
narrative now reads as 10-11 distinct cards (大分類 / 素質 / 人生観 /
潜在能力 / 思考タイプ / 対話における思考方法 / リスク・リターンの考え方 /
仕事の素質 / 向いている役割 / モチベが出やすい環境 / 性格番号 for
Japanese; equivalents for English).

Implements #35.

## Approach

Rather than re-implement every v0.19.1 organism, this change keeps the
proven `getPersonalityMarkdown` pipeline and parses its output into
sections client-side. The Markdown already has clear `##` section
breaks — splitting on those produces the same visual structure the
v0.19.1 components achieved through six bespoke organism files.

## What landed

- `packages/web/src/lib/personality-sections.ts` —
  `splitMarkdownIntoSections(markdown): { intro, sections[] }`. Pure
  helper, no side effects, stable slug ids for keys + future anchor
  navigation.
- `packages/web/src/lib/personality-sections.spec.ts` — section
  separation, trailing section without sentinel, empty input, slug
  stability across English and Japanese.
- `packages/web/src/lib/dantalion.ts` — extends
  `LocalizedPersonalityPreview` with `introHtml` and `sections`
  (sanitized HTML pre-rendered via the existing pipeline). The
  legacy `html` field is preserved so any downstream consumer keeps
  working.
- `packages/web/src/components/result/section-card.tsx` — DaisyUI
  `card` with `aria-labelledby` + `prose` body styled by the
  `@tailwindcss/typography` plugin from #31.
- `packages/web/src/components/personality-form.tsx` — the result
  region renders `<SectionCard>` for each section instead of one
  blob. Empty state, loading state, and the personalized heading from
  #34 stay unchanged.
- `personality-form.spec.tsx` — fixture preview objects extended with
  the new `introHtml` / `sections` fields so the type contract holds.

## Test plan

- [x] `pnpm run lint` exits zero
- [x] `pnpm run test` exits zero — `personality-sections.spec.ts`
      covers the helper, `personality-form.spec.tsx` continues to pass
      with the new section-aware loader fixture
- [x] `pnpm --filter @kurone-kito/dantalion-web-demo-web run build`
      succeeds; 42 SSG routes prerender
- [ ] CI matrix green — verified post-merge

## Follow-ups deferred to the rest of the roadmap

- Personality file ID badge (#36) — uses the same result region.
- Share / permalink controls (#37) — same.
- Axis iconography on the Genius section card (#38) — the section
  this issue produces is now a discrete surface for #38 to attach to.
- Collapsible disclosure inside section cards (#39) — same.
- Storybook stories for `SectionCard` and friends (#40).

Closes #35

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Enhanced personality preview rendering with structured display of introduction and individual sections.

* **Tests**
  * Added comprehensive test coverage for markdown section parsing and preview rendering.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/kurone-kito/dantalion-web-demo/pull/47?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->