### PR TITLE
feat(web): personality file id badge

### DIFF
--- a/packages/web/src/components/personality-form.tsx
+++ b/packages/web/src/components/personality-form.tsx
@@ -15,6 +15,7 @@ import {
   minBirthdayValue,
   parseBirthdayValue,
 } from '../lib/personality-form';
+import { FileIdBadge } from './result/file-id-badge';
 import { SectionCard } from './result/section-card';
 
 const minimumLoadingMs = 150;
@@ -217,6 +218,7 @@ export function PersonalityForm(props: PersonalityFormProps) {
           >
             {(preview) => (
               <div class="grid gap-4">
+                <FileIdBadge genius={preview().genius} language={language()} />
                 <Show when={preview().introHtml}>
                   {(introHtml) => (
                     <div

--- a/packages/web/src/components/result/file-id-badge.tsx
+++ b/packages/web/src/components/result/file-id-badge.tsx
@@ -1,0 +1,53 @@
+import { createSignal, Show } from 'solid-js';
+import { useWebCopy } from '../../i18n/web-copy';
+import {
+  type Genius,
+  getGeniusPath,
+  type SupportedLanguage,
+} from '../../lib/dantalion';
+
+export type FileIdBadgeProps = {
+  genius: Genius;
+  language: SupportedLanguage;
+};
+
+export function FileIdBadge(props: FileIdBadgeProps) {
+  const copy = useWebCopy();
+  const [copied, setCopied] = createSignal(false);
+
+  const handleCopy = async () => {
+    try {
+      await navigator.clipboard.writeText(props.genius);
+      setCopied(true);
+      window.setTimeout(() => setCopied(false), 2500);
+    } catch {
+      // clipboard might be unavailable (e.g. test envs); badge stays usable
+    }
+  };
+
+  return (
+    <div class="flex flex-wrap items-center gap-3">
+      <a
+        aria-describedby="file-id-hint"
+        class="badge badge-outline badge-lg gap-2 hover:badge-primary"
+        href={getGeniusPath(props.language, props.genius)}
+      >
+        <span class="text-xs uppercase tracking-wide opacity-70">
+          {copy().result.fileId}
+        </span>
+        <span class="font-mono text-base font-semibold">{props.genius}</span>
+      </a>
+      <button class="btn btn-ghost btn-xs" onClick={handleCopy} type="button">
+        {copy().result.fileIdCopy}
+      </button>
+      <Show when={copied()}>
+        <span aria-live="polite" class="text-xs text-success">
+          {copy().result.fileIdCopyConfirmation}
+        </span>
+      </Show>
+      <p class="sr-only" id="file-id-hint">
+        {copy().result.fileIdHint}
+      </p>
+    </div>
+  );
+}

--- a/packages/web/src/i18n/locales/en.json
+++ b/packages/web/src/i18n/locales/en.json
@@ -63,6 +63,10 @@
     }
   },
   "result": {
+    "fileId": "Personality file",
+    "fileIdCopy": "Copy ID",
+    "fileIdCopyConfirmation": "ID copied to clipboard",
+    "fileIdHint": "A stable identifier for this personality. Click to open the detail page or use the copy button to share the ID.",
     "headingTemplate": "{{nickname}}'s personality",
     "nicknameFallback": "Anonymous"
   },

--- a/packages/web/src/i18n/locales/ja.json
+++ b/packages/web/src/i18n/locales/ja.json
@@ -63,6 +63,10 @@
     }
   },
   "result": {
+    "fileId": "性格ファイル番号",
+    "fileIdCopy": "ID をコピー",
+    "fileIdCopyConfirmation": "ID をクリップボードにコピーしました",
+    "fileIdHint": "性格に対応する安定識別子です。クリックで詳細ページへ、コピーで ID を共有できます。",
     "headingTemplate": "{{nickname}}さんの性格診断",
     "nicknameFallback": "名無しの権兵衛"
   },


### PR DESCRIPTION
## Summary

Surface the personality file id as a small DaisyUI outline badge above
the section cards from #35. The badge is also a link to the per-genius
detail route for the inner genius and ships with a copy-to-clipboard
button.

Implements #36.

## What landed

- `packages/web/src/components/result/file-id-badge.tsx` — `FileIdBadge`
  with: badge link (DaisyUI `badge badge-outline badge-lg`, hover →
  `badge-primary`) wrapping the localized label + monospace genius
  code; copy button (`btn btn-ghost btn-xs`) with ARIA-live
  confirmation; sr-only hint described by the badge for screen
  readers.
- `packages/web/src/i18n/locales/{en,ja}.json` — adds `result.fileId`,
  `result.fileIdCopy`, `result.fileIdCopyConfirmation`,
  `result.fileIdHint` (Japanese mirrors v0.19.1's
  `web.result.profile = "性格ファイル番号"`).
- `packages/web/src/components/personality-form.tsx` — mounts the
  badge at the top of the result region above the existing intro and
  section cards from #35.

## Test plan

- [x] `pnpm run lint` exits zero
- [x] `pnpm run test` exits zero (no regressions)
- [x] `pnpm --filter @kurone-kito/dantalion-web-demo-web run build`
      succeeds; 42 SSG routes prerender
- [ ] CI matrix green — verified post-merge

Closes #36

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added a personality file ID badge to generated results that displays a stable identifier, allowing users to copy and share it with others.
  * Localization support added for file ID labels and copy confirmations in English and Japanese.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/kurone-kito/dantalion-web-demo/pull/48?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->