### PR TITLE
feat(web): collapsible section disclosure

### DIFF
--- a/packages/web/src/app.css
+++ b/packages/web/src/app.css
@@ -12,6 +12,18 @@ body {
   min-height: 100vh;
 }
 
+details > summary .when-open {
+  display: none;
+}
+
+details[open] > summary .when-closed {
+  display: none;
+}
+
+details[open] > summary .when-open {
+  display: inline;
+}
+
 @media print {
   :root {
     color-scheme: light;

--- a/packages/web/src/components/result/section-card.tsx
+++ b/packages/web/src/components/result/section-card.tsx
@@ -1,3 +1,4 @@
+import { useWebCopy } from '../../i18n/web-copy';
 import type { LocalizedPersonalitySection } from '../../lib/dantalion';
 
 export type SectionCardProps = {
@@ -6,6 +7,7 @@ export type SectionCardProps = {
 };
 
 export function SectionCard(props: SectionCardProps) {
+  const copy = useWebCopy();
   return (
     <article
       aria-labelledby={`section-${props.section.id}`}
@@ -15,7 +17,15 @@ export function SectionCard(props: SectionCardProps) {
         <h3 class="card-title text-xl" id={`section-${props.section.id}`}>
           {props.section.heading}
         </h3>
-        <div class="prose max-w-none" innerHTML={props.bodyHtml} />
+        <details class="collapse collapse-arrow rounded-box bg-base-200">
+          <summary class="collapse-title text-sm font-semibold">
+            <span class="when-closed">{copy().result.showDetails}</span>
+            <span class="when-open">{copy().result.hideDetails}</span>
+          </summary>
+          <div class="collapse-content">
+            <div class="prose max-w-none" innerHTML={props.bodyHtml} />
+          </div>
+        </details>
       </div>
     </article>
   );

--- a/packages/web/src/i18n/locales/en.json
+++ b/packages/web/src/i18n/locales/en.json
@@ -69,7 +69,9 @@
     "fileIdHint": "A stable identifier for this personality. Click to open the detail page or use the copy button to share the ID.",
     "headingTemplate": "{{nickname}}'s personality",
     "nicknameFallback": "Anonymous",
-    "printLabel": "Print result"
+    "printLabel": "Print result",
+    "showDetails": "Show details",
+    "hideDetails": "Hide details"
   },
   "geniusPage": {
     "breadcrumbHomeLabel": "Home",

--- a/packages/web/src/i18n/locales/ja.json
+++ b/packages/web/src/i18n/locales/ja.json
@@ -69,7 +69,9 @@
     "fileIdHint": "性格に対応する安定識別子です。クリックで詳細ページへ、コピーで ID を共有できます。",
     "headingTemplate": "{{nickname}}さんの性格診断",
     "nicknameFallback": "名無しの権兵衛",
-    "printLabel": "印刷する"
+    "printLabel": "印刷する",
+    "showDetails": "詳細を見る",
+    "hideDetails": "詳細を閉じる"
   },
   "geniusPage": {
     "breadcrumbHomeLabel": "ホーム",


### PR DESCRIPTION
## Summary

Wrap each personality section card body in a native `<details>` element
so the long descriptions are collapsed by default. Replaces the
v0.19.1 tooltip-driven disclosure with a keyboard- and
screen-reader-friendly native disclosure.

Implements #39.

## What landed

- `packages/web/src/components/result/section-card.tsx` — the body
  now lives inside `<details class="collapse collapse-arrow">` with a
  `<summary>` that swaps between `Show details` / `Hide details`
  (`詳細を見る` / `詳細を閉じる`) via two inline spans toggled by
  `<details>[open]`.
- `packages/web/src/app.css` — `.when-open` / `.when-closed` helpers
  flip based on the native `[open]` attribute. No JavaScript needed
  for the toggle.
- `packages/web/src/i18n/locales/{en,ja}.json` — adds
  `result.showDetails` and `result.hideDetails`.

## Print continuity

The print stylesheet from #41 already forces `details { display: block }`
and the `summary` is `pointer-events: none` in print, so paper output
includes every section's full text without manual expansion. No
additional rules needed.

## Accessibility

`<details>` is keyboard-accessible by default and announces the
disclosure state via the native `aria-expanded` attribute. No bespoke
ARIA wiring required.

## Test plan

- [x] `pnpm run lint` exits zero
- [x] `pnpm run test` exits zero (no regressions; the section card
      surface stays type-compatible)
- [x] `pnpm --filter @kurone-kito/dantalion-web-demo-web run build`
      succeeds; 42 SSG routes prerender
- [ ] CI matrix green — verified post-merge

Closes #39

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Section details are now collapsible with toggle controls ("Show Details" / "Hide Details")
  * Localization support added for English and Japanese UI labels

* **Styling**
  * Enhanced print styles for expandable content sections

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/kurone-kito/dantalion-web-demo/pull/50?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->