### PR TITLE
feat(web): share menu + permalink url state

### DIFF
--- a/packages/web/src/components/personality-form.tsx
+++ b/packages/web/src/components/personality-form.tsx
@@ -1,4 +1,11 @@
-import { createMemo, createResource, createSignal, For, Show } from 'solid-js';
+import {
+  createMemo,
+  createResource,
+  createSignal,
+  For,
+  onMount,
+  Show,
+} from 'solid-js';
 import { useWebCopy } from '../i18n/web-copy';
 import {
   getGeniusPath,
@@ -7,6 +14,7 @@ import {
 } from '../lib/dantalion';
 import { formatHeading, normalizeNickname } from '../lib/heading';
 import { useLocale } from '../lib/locale-context';
+import { decodePermalink, encodePermalink } from '../lib/permalink';
 import {
   defaultBirthdayValue,
   getPersonalityFormCopy,
@@ -18,6 +26,7 @@ import {
 import { FileIdBadge } from './result/file-id-badge';
 import { PrintButton } from './result/print-button';
 import { SectionCard } from './result/section-card';
+import { ShareMenu } from './result/share-menu';
 
 const minimumLoadingMs = 150;
 const nicknameMaxLength = 32;
@@ -71,6 +80,22 @@ export function PersonalityForm(props: PersonalityFormProps) {
     isBirthdayInSupportedRange(dateValue()) ? null : copy().invalidRangeMessage,
   );
 
+  const submit = (request: { value: string; nickname: string | undefined }) => {
+    setSubmission({
+      nickname: request.nickname,
+      nonce: Date.now(),
+      value: request.value,
+    });
+    if (typeof window !== 'undefined' && window.history?.replaceState) {
+      const next = encodePermalink({
+        birthday: request.value,
+        language: language(),
+        nickname: request.nickname,
+      });
+      window.history.replaceState(window.history.state, '', next);
+    }
+  };
+
   const handleSubmit = (event: SubmitEvent) => {
     event.preventDefault();
 
@@ -78,12 +103,26 @@ export function PersonalityForm(props: PersonalityFormProps) {
       return;
     }
 
-    setSubmission({
+    submit({
       nickname: normalizeNickname(nicknameValue(), nicknameMaxLength),
-      nonce: Date.now(),
       value: dateValue(),
     });
   };
+
+  onMount(() => {
+    if (typeof window === 'undefined' || props.loadPersonality) {
+      return;
+    }
+    const { birthday, nickname } = decodePermalink(window.location.search);
+    if (!birthday) {
+      return;
+    }
+    setDateValue(birthday);
+    if (nickname) {
+      setNicknameValue(nickname);
+    }
+    submit({ nickname, value: birthday });
+  });
 
   const handleReset = () => {
     setDateValue(defaultBirthdayValue);
@@ -224,7 +263,18 @@ export function PersonalityForm(props: PersonalityFormProps) {
                     genius={preview().genius}
                     language={language()}
                   />
-                  <PrintButton />
+                  <div
+                    class="flex flex-wrap items-center gap-2"
+                    data-print-hidden="true"
+                  >
+                    <ShareMenu
+                      birthday={submission()?.value ?? dateValue()}
+                      genius={preview().genius}
+                      language={language()}
+                      nickname={submission()?.nickname}
+                    />
+                    <PrintButton />
+                  </div>
                 </div>
                 <Show when={preview().introHtml}>
                   {(introHtml) => (

--- a/packages/web/src/components/result/share-menu.tsx
+++ b/packages/web/src/components/result/share-menu.tsx
@@ -1,0 +1,119 @@
+import { createSignal, Show } from 'solid-js';
+import { useWebCopy } from '../../i18n/web-copy';
+import type { Genius, SupportedLanguage } from '../../lib/dantalion';
+import { encodePermalink } from '../../lib/permalink';
+
+const SITE_ORIGIN_FALLBACK = 'https://kurone-kito.github.io/dantalion';
+
+const resolveSiteOrigin = (): string => {
+  if (typeof window === 'undefined') {
+    return SITE_ORIGIN_FALLBACK;
+  }
+  const origin = window.location.origin;
+  const base = window.location.pathname.split('/').slice(0, 2).join('/');
+  return `${origin}${base}`.replace(/\/+$/u, '');
+};
+
+export type ShareMenuProps = {
+  birthday: string;
+  genius: Genius;
+  language: SupportedLanguage;
+  nickname?: string | undefined;
+};
+
+export function ShareMenu(props: ShareMenuProps) {
+  const copy = useWebCopy();
+  const [copied, setCopied] = createSignal(false);
+  const canShare = typeof navigator !== 'undefined' && 'share' in navigator;
+
+  const buildShareUrl = (): string => {
+    const path = encodePermalink({
+      birthday: props.birthday,
+      language: props.language,
+      nickname: props.nickname,
+    });
+    return `${resolveSiteOrigin()}${path}`;
+  };
+
+  const buildShareText = (): string =>
+    copy().share.hookTemplate.replaceAll('{{genius}}', props.genius);
+
+  const handleWebShare = async () => {
+    if (!canShare) return;
+    try {
+      await navigator.share({
+        url: buildShareUrl(),
+        text: buildShareText(),
+        title: copy().demoPage.metaTitle,
+      });
+    } catch {
+      // User cancelled or share failed — ignore silently
+    }
+  };
+
+  const handleCopyLink = async () => {
+    try {
+      await navigator.clipboard.writeText(buildShareUrl());
+      setCopied(true);
+      window.setTimeout(() => setCopied(false), 2500);
+    } catch {
+      // clipboard unavailable
+    }
+  };
+
+  const composeIntent = (base: string): string => {
+    const params = new URLSearchParams({
+      text: buildShareText(),
+      url: buildShareUrl(),
+      hashtags: copy().share.hashtag,
+    });
+    return `${base}?${params.toString()}`;
+  };
+
+  return (
+    <div class="dropdown dropdown-end" data-print-hidden="true">
+      <button class="btn btn-primary btn-sm" tabindex="0" type="button">
+        {copy().share.trigger}
+      </button>
+      <ul class="menu dropdown-content z-10 mt-2 w-56 rounded-box border border-base-300 bg-base-100 p-2 shadow-xl">
+        <Show when={canShare}>
+          <li>
+            <button onClick={handleWebShare} type="button">
+              {copy().share.items.webShare}
+            </button>
+          </li>
+        </Show>
+        <li>
+          <button onClick={handleCopyLink} type="button">
+            {copy().share.items.copyLink}
+          </button>
+        </li>
+        <li>
+          <a
+            href={composeIntent('https://x.com/intent/post')}
+            rel="noreferrer noopener"
+            target="_blank"
+          >
+            {copy().share.items.x}
+          </a>
+        </li>
+        <li>
+          <a
+            href={`https://bsky.app/intent/compose?text=${encodeURIComponent(
+              `${buildShareText()} ${buildShareUrl()}`,
+            )}`}
+            rel="noreferrer noopener"
+            target="_blank"
+          >
+            {copy().share.items.bluesky}
+          </a>
+        </li>
+      </ul>
+      <Show when={copied()}>
+        <span aria-live="polite" class="ml-2 text-xs text-success">
+          {copy().share.copiedToast}
+        </span>
+      </Show>
+    </div>
+  );
+}

--- a/packages/web/src/i18n/locales/en.json
+++ b/packages/web/src/i18n/locales/en.json
@@ -73,6 +73,18 @@
     "showDetails": "Show details",
     "hideDetails": "Hide details"
   },
+  "share": {
+    "trigger": "Share result",
+    "items": {
+      "webShare": "Share…",
+      "copyLink": "Copy link",
+      "x": "Share on X",
+      "bluesky": "Share on Bluesky"
+    },
+    "copiedToast": "Permalink copied to clipboard",
+    "hookTemplate": "I am personality {{genius}} on the dantalion demo.",
+    "hashtag": "Dantalion"
+  },
   "geniusPage": {
     "breadcrumbHomeLabel": "Home",
     "ctaLabel": "Find your genius",

--- a/packages/web/src/i18n/locales/ja.json
+++ b/packages/web/src/i18n/locales/ja.json
@@ -73,6 +73,18 @@
     "showDetails": "詳細を見る",
     "hideDetails": "詳細を閉じる"
   },
+  "share": {
+    "trigger": "共有する",
+    "items": {
+      "webShare": "共有…",
+      "copyLink": "リンクをコピー",
+      "x": "X で共有",
+      "bluesky": "Bluesky で共有"
+    },
+    "copiedToast": "パーマリンクをクリップボードにコピーしました",
+    "hookTemplate": "dantalion デモで、私の性格タイプは {{genius}} でした。",
+    "hashtag": "Dantalion性格診断"
+  },
   "geniusPage": {
     "breadcrumbHomeLabel": "ホーム",
     "ctaLabel": "診断トップへ戻る",

--- a/packages/web/src/lib/permalink.spec.ts
+++ b/packages/web/src/lib/permalink.spec.ts
@@ -1,0 +1,72 @@
+import { describe, expect, it } from 'vitest';
+import { decodePermalink, encodePermalink } from './permalink';
+
+describe('encodePermalink', () => {
+  it('builds the standard URL shape with both fields', () => {
+    expect(
+      encodePermalink({
+        birthday: '2000-01-01',
+        language: 'en',
+        nickname: 'Alice',
+      }),
+    ).toBe('/en/?d=2000-01-01&n=Alice');
+  });
+
+  it('omits the n parameter when nickname is undefined', () => {
+    expect(encodePermalink({ birthday: '2000-01-01', language: 'ja' })).toBe(
+      '/ja/?d=2000-01-01',
+    );
+  });
+
+  it('URL-encodes nicknames with special characters', () => {
+    const url = encodePermalink({
+      birthday: '2000-01-01',
+      language: 'en',
+      nickname: 'Bob & Alice',
+    });
+    expect(url).toBe('/en/?d=2000-01-01&n=Bob+%26+Alice');
+  });
+});
+
+describe('decodePermalink', () => {
+  it('returns the birthday when present and in range', () => {
+    expect(decodePermalink('d=2000-01-01&n=Alice')).toEqual({
+      birthday: '2000-01-01',
+      nickname: 'Alice',
+    });
+  });
+
+  it('returns nickname undefined when n is absent', () => {
+    expect(decodePermalink('d=2000-01-01')).toEqual({
+      birthday: '2000-01-01',
+      nickname: undefined,
+    });
+  });
+
+  it('rejects birthdays outside the supported range', () => {
+    expect(decodePermalink('d=1700-01-01')).toEqual({
+      birthday: null,
+      nickname: undefined,
+    });
+  });
+
+  it('rejects malformed dates', () => {
+    expect(decodePermalink('d=not-a-date')).toEqual({
+      birthday: null,
+      nickname: undefined,
+    });
+  });
+
+  it('truncates overlong nicknames to 32 characters', () => {
+    const overlong = 'a'.repeat(48);
+    expect(decodePermalink(`d=2000-01-01&n=${overlong}`).nickname).toHaveLength(
+      32,
+    );
+  });
+
+  it('treats whitespace-only nickname as undefined', () => {
+    expect(
+      decodePermalink('d=2000-01-01&n=%20%20%20').nickname,
+    ).toBeUndefined();
+  });
+});

--- a/packages/web/src/lib/permalink.ts
+++ b/packages/web/src/lib/permalink.ts
@@ -1,0 +1,39 @@
+import type { SupportedLanguage } from './dantalion';
+import { isBirthdayInSupportedRange } from './personality-form';
+
+export type PermalinkInput = {
+  birthday: string;
+  language: SupportedLanguage;
+  nickname?: string | undefined;
+};
+
+export const encodePermalink = ({
+  birthday,
+  language,
+  nickname,
+}: PermalinkInput): string => {
+  const params = new URLSearchParams();
+  params.set('d', birthday);
+  if (nickname) {
+    params.set('n', nickname);
+  }
+  return `/${language}/?${params.toString()}`;
+};
+
+export type DecodedPermalink = {
+  birthday: string | null;
+  nickname: string | undefined;
+};
+
+export const decodePermalink = (
+  search: string | URLSearchParams,
+): DecodedPermalink => {
+  const params =
+    typeof search === 'string' ? new URLSearchParams(search) : search;
+  const rawBirthday = params.get('d') ?? '';
+  const birthday = isBirthdayInSupportedRange(rawBirthday) ? rawBirthday : null;
+  const rawNickname = params.get('n')?.trim() ?? '';
+  const nickname =
+    rawNickname.length > 0 ? rawNickname.slice(0, 32) : undefined;
+  return { birthday, nickname };
+};


### PR DESCRIPTION
## Summary

Add a permalink URL state (`/<lang>/?d=YYYY-MM-DD&n=<nickname>`) plus
a DaisyUI dropdown share menu exposing the Web Share API, copy-link,
and X / Bluesky compose intents. The form auto-fills + auto-submits
from the URL on mount so shared permalinks re-open the same result
without retyping.

Implements #37.

## What landed

- `packages/web/src/lib/permalink.ts` — `encodePermalink({ birthday,
  language, nickname })` builds the URL; `decodePermalink(search)`
  validates against `isBirthdayInSupportedRange`, truncates nicknames
  to 32 chars, and treats whitespace-only nickname as `undefined`.
- `packages/web/src/lib/permalink.spec.ts` — covers both happy paths
  and rejection cases (out-of-range birthday, malformed date,
  overlong nickname, whitespace-only nickname, encoding special
  characters).
- `packages/web/src/components/personality-form.tsx`:
  - submit handler now calls `history.replaceState` with the encoded
    permalink (so re-submits don't pollute the back stack).
  - new `onMount` hook reads `window.location.search`, pre-fills the
    form, and auto-submits when the URL has a valid `d` parameter.
  - mounts `<ShareMenu>` next to the file id badge.
- `packages/web/src/components/result/share-menu.tsx` — DaisyUI
  dropdown:
  - `Share…` (only when `navigator.share` exists)
  - `Copy link` (clipboard + ARIA-live toast)
  - `Share on X` (`https://x.com/intent/post?text=&url=&hashtags=`)
  - `Share on Bluesky` (`https://bsky.app/intent/compose?text=…`)
- `packages/web/src/i18n/locales/{en,ja}.json` — adds `share.*`
  (trigger, items, copiedToast, hookTemplate, hashtag).

## Privacy continuity

Permalinks are a user-initiated URL. They include the birthday and
optional nickname in the query string. The original privacy callout
(introduced in #33) already promises "nothing leaves this tab without
your action" — sharing a permalink is that action. (A follow-up to
extend the callout copy explicitly is worth doing, but is left out of
this PR's scope.)

## Test plan

- [x] `pnpm run lint` exits zero
- [x] `pnpm run test` exits zero — `permalink.spec.ts` covers the
      encoder + decoder; existing suites pass unchanged
- [x] `pnpm --filter @kurone-kito/dantalion-web-demo-web run build`
      succeeds; 42 SSG routes prerender
- [ ] CI matrix green — verified post-merge
- [ ] Manual: refresh `/en/?d=2000-01-01&n=Alice` shows the form
      pre-filled with Alice and the personalized heading
- [ ] Manual: Share dropdown's Copy link copies the current URL to
      clipboard and shows the toast

Closes #37

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added multi-platform sharing options: native web share, copy link, X, and Bluesky.
  * Results can be shared via personalized permalinks that preserve form state.
  * Users can load results from shared links to recreate previous results.
  * Added share feature localization for English and Japanese.

* **Tests**
  * Added permalink encoding and decoding test coverage.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/kurone-kito/dantalion-web-demo/pull/51?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->