### PR TITLE
chore(web): storybook stories for new components

### DIFF
--- a/packages/web/src/components/landing/feature-section.stories.tsx
+++ b/packages/web/src/components/landing/feature-section.stories.tsx
@@ -1,0 +1,28 @@
+import type { Meta, StoryObj } from 'storybook-solidjs-vite';
+import { LocaleProvider } from '../../lib/locale-context';
+import { FeatureSection } from './feature-section';
+
+const meta: Meta<typeof FeatureSection> = {
+  title: 'Landing/FeatureSection',
+  component: FeatureSection,
+};
+
+export default meta;
+
+type Story = StoryObj<typeof FeatureSection>;
+
+export const English: Story = {
+  render: () => (
+    <LocaleProvider language="en">
+      <FeatureSection />
+    </LocaleProvider>
+  ),
+};
+
+export const Japanese: Story = {
+  render: () => (
+    <LocaleProvider language="ja">
+      <FeatureSection />
+    </LocaleProvider>
+  ),
+};

--- a/packages/web/src/components/landing/hero-section.stories.tsx
+++ b/packages/web/src/components/landing/hero-section.stories.tsx
@@ -1,0 +1,28 @@
+import type { Meta, StoryObj } from 'storybook-solidjs-vite';
+import { LocaleProvider } from '../../lib/locale-context';
+import { HeroSection } from './hero-section';
+
+const meta: Meta<typeof HeroSection> = {
+  title: 'Landing/HeroSection',
+  component: HeroSection,
+};
+
+export default meta;
+
+type Story = StoryObj<typeof HeroSection>;
+
+export const English: Story = {
+  render: () => (
+    <LocaleProvider language="en">
+      <HeroSection />
+    </LocaleProvider>
+  ),
+};
+
+export const Japanese: Story = {
+  render: () => (
+    <LocaleProvider language="ja">
+      <HeroSection />
+    </LocaleProvider>
+  ),
+};

--- a/packages/web/src/components/landing/install-section.stories.tsx
+++ b/packages/web/src/components/landing/install-section.stories.tsx
@@ -1,0 +1,28 @@
+import type { Meta, StoryObj } from 'storybook-solidjs-vite';
+import { LocaleProvider } from '../../lib/locale-context';
+import { InstallSection } from './install-section';
+
+const meta: Meta<typeof InstallSection> = {
+  title: 'Landing/InstallSection',
+  component: InstallSection,
+};
+
+export default meta;
+
+type Story = StoryObj<typeof InstallSection>;
+
+export const English: Story = {
+  render: () => (
+    <LocaleProvider language="en">
+      <InstallSection />
+    </LocaleProvider>
+  ),
+};
+
+export const Japanese: Story = {
+  render: () => (
+    <LocaleProvider language="ja">
+      <InstallSection />
+    </LocaleProvider>
+  ),
+};

--- a/packages/web/src/components/landing/preface-section.stories.tsx
+++ b/packages/web/src/components/landing/preface-section.stories.tsx
@@ -1,0 +1,28 @@
+import type { Meta, StoryObj } from 'storybook-solidjs-vite';
+import { LocaleProvider } from '../../lib/locale-context';
+import { PrefaceSection } from './preface-section';
+
+const meta: Meta<typeof PrefaceSection> = {
+  title: 'Landing/PrefaceSection',
+  component: PrefaceSection,
+};
+
+export default meta;
+
+type Story = StoryObj<typeof PrefaceSection>;
+
+export const English: Story = {
+  render: () => (
+    <LocaleProvider language="en">
+      <PrefaceSection />
+    </LocaleProvider>
+  ),
+};
+
+export const Japanese: Story = {
+  render: () => (
+    <LocaleProvider language="ja">
+      <PrefaceSection />
+    </LocaleProvider>
+  ),
+};

--- a/packages/web/src/components/landing/privacy-callout.stories.tsx
+++ b/packages/web/src/components/landing/privacy-callout.stories.tsx
@@ -1,0 +1,28 @@
+import type { Meta, StoryObj } from 'storybook-solidjs-vite';
+import { LocaleProvider } from '../../lib/locale-context';
+import { PrivacyCallout } from './privacy-callout';
+
+const meta: Meta<typeof PrivacyCallout> = {
+  title: 'Landing/PrivacyCallout',
+  component: PrivacyCallout,
+};
+
+export default meta;
+
+type Story = StoryObj<typeof PrivacyCallout>;
+
+export const English: Story = {
+  render: () => (
+    <LocaleProvider language="en">
+      <PrivacyCallout />
+    </LocaleProvider>
+  ),
+};
+
+export const Japanese: Story = {
+  render: () => (
+    <LocaleProvider language="ja">
+      <PrivacyCallout />
+    </LocaleProvider>
+  ),
+};

--- a/packages/web/src/components/landing/repo-cta.stories.tsx
+++ b/packages/web/src/components/landing/repo-cta.stories.tsx
@@ -1,0 +1,28 @@
+import type { Meta, StoryObj } from 'storybook-solidjs-vite';
+import { LocaleProvider } from '../../lib/locale-context';
+import { RepoCta } from './repo-cta';
+
+const meta: Meta<typeof RepoCta> = {
+  title: 'Landing/RepoCta',
+  component: RepoCta,
+};
+
+export default meta;
+
+type Story = StoryObj<typeof RepoCta>;
+
+export const English: Story = {
+  render: () => (
+    <LocaleProvider language="en">
+      <RepoCta />
+    </LocaleProvider>
+  ),
+};
+
+export const Japanese: Story = {
+  render: () => (
+    <LocaleProvider language="ja">
+      <RepoCta />
+    </LocaleProvider>
+  ),
+};

--- a/packages/web/src/components/result/file-id-badge.stories.tsx
+++ b/packages/web/src/components/result/file-id-badge.stories.tsx
@@ -1,0 +1,28 @@
+import type { Meta, StoryObj } from 'storybook-solidjs-vite';
+import { LocaleProvider } from '../../lib/locale-context';
+import { FileIdBadge } from './file-id-badge';
+
+const meta: Meta<typeof FileIdBadge> = {
+  title: 'Result/FileIdBadge',
+  component: FileIdBadge,
+};
+
+export default meta;
+
+type Story = StoryObj<typeof FileIdBadge>;
+
+export const English: Story = {
+  render: () => (
+    <LocaleProvider language="en">
+      <FileIdBadge genius="100" language="en" />
+    </LocaleProvider>
+  ),
+};
+
+export const Japanese: Story = {
+  render: () => (
+    <LocaleProvider language="ja">
+      <FileIdBadge genius="100" language="ja" />
+    </LocaleProvider>
+  ),
+};

--- a/packages/web/src/components/result/section-card.stories.tsx
+++ b/packages/web/src/components/result/section-card.stories.tsx
@@ -1,0 +1,37 @@
+import type { Meta, StoryObj } from 'storybook-solidjs-vite';
+import { LocaleProvider } from '../../lib/locale-context';
+import { SectionCard } from './section-card';
+
+const meta: Meta<typeof SectionCard> = {
+  title: 'Result/SectionCard',
+  component: SectionCard,
+};
+
+export default meta;
+
+type Story = StoryObj<typeof SectionCard>;
+
+const sampleBody =
+  '<p>This is the first paragraph of the section body. Tailwind Typography styles this through the .prose class.</p><p>A second paragraph follows. The collapsible disclosure from #39 hides the body by default; the consumer can expand it via the summary toggle.</p>';
+
+export const English: Story = {
+  render: () => (
+    <LocaleProvider language="en">
+      <SectionCard
+        bodyHtml={sampleBody}
+        section={{ heading: 'Major categories of personality', id: 'sample' }}
+      />
+    </LocaleProvider>
+  ),
+};
+
+export const Japanese: Story = {
+  render: () => (
+    <LocaleProvider language="ja">
+      <SectionCard
+        bodyHtml={sampleBody}
+        section={{ heading: '性格の大分類', id: 'sample' }}
+      />
+    </LocaleProvider>
+  ),
+};

--- a/packages/web/src/components/result/share-menu.stories.tsx
+++ b/packages/web/src/components/result/share-menu.stories.tsx
@@ -1,0 +1,38 @@
+import type { Meta, StoryObj } from 'storybook-solidjs-vite';
+import { LocaleProvider } from '../../lib/locale-context';
+import { ShareMenu } from './share-menu';
+
+const meta: Meta<typeof ShareMenu> = {
+  title: 'Result/ShareMenu',
+  component: ShareMenu,
+};
+
+export default meta;
+
+type Story = StoryObj<typeof ShareMenu>;
+
+export const English: Story = {
+  render: () => (
+    <LocaleProvider language="en">
+      <ShareMenu
+        birthday="2000-01-01"
+        genius="100"
+        language="en"
+        nickname="Alice"
+      />
+    </LocaleProvider>
+  ),
+};
+
+export const Japanese: Story = {
+  render: () => (
+    <LocaleProvider language="ja">
+      <ShareMenu
+        birthday="2000-01-01"
+        genius="100"
+        language="ja"
+        nickname="アリス"
+      />
+    </LocaleProvider>
+  ),
+};


### PR DESCRIPTION
## Summary

Baseline Storybook coverage for the nine new components introduced by
the v1.1 work so far. Each component gets a meta + an `English` and a
`Japanese` story wrapped in `<LocaleProvider>`; the theme toolbar
from #27 covers light / dark switching globally so no separate dark
story is required per component.

Implements #40.

## What landed

- `packages/web/src/components/landing/*.stories.tsx` for the six
  landing components (hero, preface, feature, install, repo-cta,
  privacy-callout).
- `packages/web/src/components/result/*.stories.tsx` for
  `SectionCard`, `FileIdBadge`, `ShareMenu`.

## Deferred to other issues

- Axis-icon component stories land in #38 (the icons themselves are
  introduced there).
- `storybook-fixtures.ts` (shared personality / accessor fixtures) is
  not required for these stories — each ShareMenu / FileIdBadge /
  SectionCard story passes literal props. If a future story needs a
  realistic accessors fixture, that helper can be extracted then.

## Test plan

- [x] `pnpm run lint` exits zero
- [x] `pnpm run test` exits zero (story files are not picked up by
      vitest because they live under `*.stories.tsx`, not `*.spec.tsx`)
- [x] `pnpm --filter @kurone-kito/dantalion-web-demo-web run story:build`
      exits zero — the static catalog enumerates the new stories
- [ ] CI matrix green — verified post-merge (`story:build` is already
      gated by the CI workflow from #16)

Closes #40

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added Storybook stories for 9 landing and result components with bilingual support (English and Japanese).
  * Each component now includes locale-specific story variants for visualization and testing across language settings.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/kurone-kito/dantalion-web-demo/pull/52?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->