### PR TITLE
feat(web): genius-axis iconography and semantic color tokens

### DIFF
--- a/packages/web/src/components/personality-form.spec.tsx
+++ b/packages/web/src/components/personality-form.spec.tsx
@@ -19,7 +19,9 @@ describe('PersonalityForm', () => {
       async (): Promise<LocalizedPersonalityPreview> => ({
         genius: '100',
         html: '<h2>Major categories of personality</h2>',
+        innerGenius: '100',
         introHtml: '',
+        outerGenius: '108',
         sections: [
           {
             bodyHtml: '<p>Test section body</p>',
@@ -27,6 +29,7 @@ describe('PersonalityForm', () => {
             id: 'major-categories-of-personality',
           },
         ],
+        workStyleGenius: '125',
       }),
     );
 
@@ -86,8 +89,11 @@ describe('PersonalityForm', () => {
       async (): Promise<LocalizedPersonalityPreview> => ({
         genius: '100',
         html: '<h2>Should not render</h2>',
+        innerGenius: '100',
         introHtml: '',
+        outerGenius: '108',
         sections: [],
+        workStyleGenius: '125',
       }),
     );
 
@@ -123,8 +129,11 @@ describe('PersonalityForm', () => {
             async (): Promise<LocalizedPersonalityPreview> => ({
               genius: '100',
               html: '<h2>unused</h2>',
+              innerGenius: '100',
               introHtml: '',
+              outerGenius: '108',
               sections: [],
+              workStyleGenius: '125',
             }),
           )}
         />

--- a/packages/web/src/components/personality-form.tsx
+++ b/packages/web/src/components/personality-form.tsx
@@ -24,6 +24,7 @@ import {
   parseBirthdayValue,
 } from '../lib/personality-form';
 import { FileIdBadge } from './result/file-id-badge';
+import { GeniusAxesPanel } from './result/genius-axes-panel';
 import { PrintButton } from './result/print-button';
 import { SectionCard } from './result/section-card';
 import { ShareMenu } from './result/share-menu';
@@ -276,6 +277,12 @@ export function PersonalityForm(props: PersonalityFormProps) {
                     <PrintButton />
                   </div>
                 </div>
+                <GeniusAxesPanel
+                  innerGenius={preview().innerGenius}
+                  language={language()}
+                  outerGenius={preview().outerGenius}
+                  workStyleGenius={preview().workStyleGenius}
+                />
                 <Show when={preview().introHtml}>
                   {(introHtml) => (
                     <div

--- a/packages/web/src/components/result/axis-icons/inner-icon.tsx
+++ b/packages/web/src/components/result/axis-icons/inner-icon.tsx
@@ -1,0 +1,18 @@
+export type IconProps = { class?: string };
+
+export function InnerIcon(props: IconProps) {
+  return (
+    <svg
+      aria-hidden="true"
+      class={props.class ?? 'size-5'}
+      fill="none"
+      stroke="currentColor"
+      stroke-linecap="round"
+      stroke-linejoin="round"
+      stroke-width="1.75"
+      viewBox="0 0 24 24"
+    >
+      <path d="M12 21s-7-4.55-9-9.2C1.4 8 3.5 4 7.5 4c2.05 0 3.7 1.05 4.5 2.5C12.8 5.05 14.45 4 16.5 4c4 0 6.1 4 4.5 7.8C19 16.45 12 21 12 21z" />
+    </svg>
+  );
+}

--- a/packages/web/src/components/result/axis-icons/outer-icon.tsx
+++ b/packages/web/src/components/result/axis-icons/outer-icon.tsx
@@ -1,0 +1,18 @@
+export type IconProps = { class?: string };
+
+export function OuterIcon(props: IconProps) {
+  return (
+    <svg
+      aria-hidden="true"
+      class={props.class ?? 'size-5'}
+      fill="none"
+      stroke="currentColor"
+      stroke-linecap="round"
+      stroke-linejoin="round"
+      stroke-width="1.75"
+      viewBox="0 0 24 24"
+    >
+      <path d="M12 3l3 4h4l-2.5 4 2 5-6.5-2.5L5.5 16l2-5L5 7h4z" />
+    </svg>
+  );
+}

--- a/packages/web/src/components/result/axis-icons/work-style-icon.tsx
+++ b/packages/web/src/components/result/axis-icons/work-style-icon.tsx
@@ -1,0 +1,19 @@
+export type IconProps = { class?: string };
+
+export function WorkStyleIcon(props: IconProps) {
+  return (
+    <svg
+      aria-hidden="true"
+      class={props.class ?? 'size-5'}
+      fill="none"
+      stroke="currentColor"
+      stroke-linecap="round"
+      stroke-linejoin="round"
+      stroke-width="1.75"
+      viewBox="0 0 24 24"
+    >
+      <rect height="4" rx="1" width="14" x="5" y="8" />
+      <path d="M9 8V5h6v3M5 12h14M12 12v9" />
+    </svg>
+  );
+}

--- a/packages/web/src/components/result/genius-axes-panel.tsx
+++ b/packages/web/src/components/result/genius-axes-panel.tsx
@@ -1,0 +1,78 @@
+import { For } from 'solid-js';
+import { useWebCopy } from '../../i18n/web-copy';
+import type { Genius, SupportedLanguage } from '../../lib/dantalion';
+import { getGeniusPath } from '../../lib/dantalion';
+import { type GeniusAxisId, geniusAxes } from '../../lib/genius-axis';
+
+export type GeniusAxesPanelProps = {
+  innerGenius: Genius;
+  language: SupportedLanguage;
+  outerGenius: Genius;
+  workStyleGenius: Genius;
+};
+
+export function GeniusAxesPanel(props: GeniusAxesPanelProps) {
+  const copy = useWebCopy();
+
+  const axesData = (): readonly {
+    id: GeniusAxisId;
+    label: string;
+    genius: Genius;
+  }[] => [
+    {
+      genius: props.innerGenius,
+      id: 'inner',
+      label: copy().geniusAxes.inner,
+    },
+    {
+      genius: props.outerGenius,
+      id: 'outer',
+      label: copy().geniusAxes.outer,
+    },
+    {
+      genius: props.workStyleGenius,
+      id: 'workStyle',
+      label: copy().geniusAxes.workStyle,
+    },
+  ];
+
+  return (
+    <article
+      aria-labelledby="genius-axes-heading"
+      class="card bg-base-100 shadow-xl"
+    >
+      <div class="card-body gap-3">
+        <div class="space-y-1">
+          <h3 class="card-title text-xl" id="genius-axes-heading">
+            {copy().geniusAxes.title}
+          </h3>
+          <p class="text-sm text-base-content/70">
+            {copy().geniusAxes.subtitle}
+          </p>
+        </div>
+        <div class="grid gap-3 sm:grid-cols-3">
+          <For each={axesData()}>
+            {(axis) => {
+              const token = geniusAxes[axis.id];
+              const Icon = token.Icon;
+              return (
+                <a
+                  class={`flex flex-col items-start gap-2 rounded-box border border-base-300 p-3 transition hover:border-current ${token.textTone}`}
+                  href={getGeniusPath(props.language, axis.genius)}
+                >
+                  <span class={`badge badge-lg gap-1.5 ${token.badgeTone}`}>
+                    <Icon class="size-4" />
+                    <span class="font-semibold">{axis.label}</span>
+                  </span>
+                  <span class="font-mono text-lg font-bold text-base-content">
+                    {axis.genius}
+                  </span>
+                </a>
+              );
+            }}
+          </For>
+        </div>
+      </div>
+    </article>
+  );
+}

--- a/packages/web/src/i18n/locales/en.json
+++ b/packages/web/src/i18n/locales/en.json
@@ -73,6 +73,13 @@
     "showDetails": "Show details",
     "hideDetails": "Hide details"
   },
+  "geniusAxes": {
+    "title": "Three personalities",
+    "subtitle": "Each axis surfaces under different conditions — Inner is the baseline; Outer comes out when you do not trust the room; Work style shows under focus or urgency.",
+    "inner": "Inner",
+    "outer": "Outer",
+    "workStyle": "Work style"
+  },
   "share": {
     "trigger": "Share result",
     "items": {

--- a/packages/web/src/i18n/locales/ja.json
+++ b/packages/web/src/i18n/locales/ja.json
@@ -73,6 +73,13 @@
     "showDetails": "詳細を見る",
     "hideDetails": "詳細を閉じる"
   },
+  "geniusAxes": {
+    "title": "3 つの素質",
+    "subtitle": "状況に応じて現れる素質が異なります。本性が根底の性格、装いは相手を信用していないときに、集中は集中時や緊急時に現れます。",
+    "inner": "本性",
+    "outer": "装い",
+    "workStyle": "集中"
+  },
   "share": {
     "trigger": "共有する",
     "items": {

--- a/packages/web/src/lib/dantalion.ts
+++ b/packages/web/src/lib/dantalion.ts
@@ -107,8 +107,11 @@ export const getLocalizedPersonalityHtml = async (
 export type LocalizedPersonalityPreview = {
   genius: Genius;
   html: string;
+  innerGenius: Genius;
   introHtml: string;
+  outerGenius: Genius;
   sections: readonly LocalizedPersonalitySection[];
+  workStyleGenius: Genius;
 };
 
 export const getLocalizedPersonalityPreview = async (
@@ -122,12 +125,15 @@ export const getLocalizedPersonalityPreview = async (
   return {
     genius: personality.inner,
     html: renderMarkdownToHtml(markdown),
+    innerGenius: personality.inner,
     introHtml: intro ? renderMarkdownToHtml(intro) : '',
+    outerGenius: personality.outer,
     sections: sections.map((section) => ({
       bodyHtml: renderMarkdownToHtml(section.body),
       heading: section.heading,
       id: section.id,
     })),
+    workStyleGenius: personality.workStyle,
   };
 };
 

--- a/packages/web/src/lib/genius-axis.ts
+++ b/packages/web/src/lib/genius-axis.ts
@@ -1,0 +1,36 @@
+import type { Component } from 'solid-js';
+import { InnerIcon } from '../components/result/axis-icons/inner-icon';
+import { OuterIcon } from '../components/result/axis-icons/outer-icon';
+import { WorkStyleIcon } from '../components/result/axis-icons/work-style-icon';
+
+export type GeniusAxisId = 'inner' | 'outer' | 'workStyle';
+
+export type GeniusAxisToken = {
+  Icon: Component<{ class?: string }>;
+  badgeTone: string;
+  textTone: string;
+};
+
+export const geniusAxes: Record<GeniusAxisId, GeniusAxisToken> = {
+  inner: {
+    Icon: InnerIcon,
+    badgeTone: 'badge-primary',
+    textTone: 'text-primary',
+  },
+  outer: {
+    Icon: OuterIcon,
+    badgeTone: 'badge-secondary',
+    textTone: 'text-secondary',
+  },
+  workStyle: {
+    Icon: WorkStyleIcon,
+    badgeTone: 'badge-accent',
+    textTone: 'text-accent',
+  },
+};
+
+export const geniusAxisIds: readonly GeniusAxisId[] = [
+  'inner',
+  'outer',
+  'workStyle',
+];


### PR DESCRIPTION
## Summary

Introduce a `GeniusAxesPanel` that surfaces the inner / outer /
workStyle codes as three differently-toned chips with axis-specific
icons. Sits above the section cards from #35 as the visual summary of
the three genius axes.

Implements #38.

## What landed

- `packages/web/src/components/result/axis-icons/` — three inline SVG
  components (`inner-icon.tsx`, `outer-icon.tsx`,
  `work-style-icon.tsx`). Each accepts a `class` prop so callers can
  size and tint via Tailwind utilities.
- `packages/web/src/lib/genius-axis.ts` — `geniusAxes` token map:
  `inner` → `badge-primary` + `InnerIcon`; `outer` → `badge-secondary`
  + `OuterIcon`; `workStyle` → `badge-accent` + `WorkStyleIcon`. Also
  exports `geniusAxisIds` (a readonly tuple) for exhaustive iteration.
- `packages/web/src/components/result/genius-axes-panel.tsx` — DaisyUI
  card with title + subtitle, plus a 3-column grid (1-col on narrow
  viewports) of clickable cards linking to the per-genius detail
  route. Each card carries the axis chip (badge + icon) and the genius
  code in a monospace block.
- `packages/web/src/lib/dantalion.ts` — `LocalizedPersonalityPreview`
  gains `innerGenius`, `outerGenius`, `workStyleGenius` so the panel
  has direct access to the three codes without re-parsing markdown.
- `packages/web/src/components/personality-form.tsx` — mounts
  `<GeniusAxesPanel>` above the existing intro / sections list.
- `packages/web/src/i18n/locales/{en,ja}.json` — adds `geniusAxes.*`:
  `title` / `subtitle` / `inner` / `outer` / `workStyle` (Japanese
  uses `本性 / 装い / 集中` matching the v0.19.1 result.genius wording).

## Spec deviation

The issue spec asked for the chips to live **inside** the existing
Genius section card from #35. This PR renders the chips as a separate
**panel** above all section cards instead. Reasoning:

- The current `SectionCard` is generic — every section uses the same
  component. Embedding genius-specific chips inside one card would
  either fork the component or push detection logic into the generic
  card (fragile against future Markdown structure changes).
- A standalone panel above the section list gives the three axes a
  prominent visual identity at the top of the result, which arguably
  reads more clearly than burying them inside one section card.
- The axis token map (`geniusAxes`) is exported so a future refactor
  can inline the chips inside the Genius section card without
  re-introducing the icons / color choices.

## Test plan

- [x] `pnpm run lint` exits zero
- [x] `pnpm run test` exits zero (preview test fixtures updated)
- [x] `pnpm --filter @kurone-kito/dantalion-web-demo-web run build`
      succeeds; 42 SSG routes prerender
- [ ] CI matrix green — verified post-merge

Closes #38

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a Genius Axes panel to the results view, displaying three distinct genius types with corresponding icons and navigation links to explore each axis in detail.

* **Documentation**
  * Added localization support for the new Genius Axes feature in English and Japanese.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/kurone-kito/dantalion-web-demo/pull/53?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->