### PR TITLE
fix(web): use Solid Router navigate for the post-submit URL replace

### DIFF
--- a/packages/web/src/components/personality-form.tsx
+++ b/packages/web/src/components/personality-form.tsx
@@ -1,4 +1,4 @@
-import { A } from '@solidjs/router';
+import { A, useNavigate } from '@solidjs/router';
 import {
   createMemo,
   createResource,
@@ -54,6 +54,7 @@ export type PersonalityLoader = (
 
 export function PersonalityForm(props: PersonalityFormProps) {
   const { language } = useLocale();
+  const navigate = useNavigate();
   const copy = createMemo(() => getPersonalityFormCopy(language()));
   const webCopy = useWebCopy();
   const loadPersonality = () =>
@@ -88,14 +89,12 @@ export function PersonalityForm(props: PersonalityFormProps) {
       nonce: Date.now(),
       value: request.value,
     });
-    if (typeof window !== 'undefined' && window.history?.replaceState) {
-      const next = encodePermalink({
-        birthday: request.value,
-        language: language(),
-        nickname: request.nickname,
-      });
-      window.history.replaceState(window.history.state, '', next);
-    }
+    const next = encodePermalink({
+      birthday: request.value,
+      language: language(),
+      nickname: request.nickname,
+    });
+    navigate(next, { replace: true, scroll: false });
   };
 
   const handleSubmit = (event: SubmitEvent) => {


### PR DESCRIPTION
## Summary

Follow-up to #62. A Playwright probe after #62 deployed showed every
click landing at `kurone-kito.github.io/en/...` (404) and the X /
Bluesky share URLs reading `kurone-kito.github.io/en/en/result/...`
(double `en`, missing `/dantalion`). Root cause: the form submit
handler called

```ts
history.replaceState(state, '', encodePermalink(...));
```

with a path like `/en/?d=2000-01-01` — no `/dantalion/` prefix.
`replaceState` is a low-level browser API that does not consult the
Solid Router base, so the URL bar lost the `/dantalion/` segment
immediately after submit. After that:

- `ShareMenu.resolveSiteOrigin()` reads `window.location.pathname`
  and gets `/en/...`, baking `kurone-kito.github.io/en` (no
  `/dantalion`) into every outbound share URL.
- The Solid Router internal route state and the URL bar drift apart,
  so `<A>` renders `/dantalion/...` hrefs (correct in DOM) but
  navigation lands at the unprefixed URL via the broken history
  state. The genius detail / file id badge / axis chip clicks
  follow that broken navigation and 404.

## Fix

Swap the bare `history.replaceState` for Solid Router's
`useNavigate(next, { replace: true, scroll: false })`. `useNavigate`
prepends the configured base (`/dantalion`) on top of the path
returned by `encodePermalink` (which stays as a base-relative
`/en/?d=...` shape), so:

- The URL bar reads `kurone-kito.github.io/dantalion/en/?d=...`.
- `window.location.pathname` reads `/dantalion/en/`.
- `ShareMenu.resolveSiteOrigin()` gets `kurone-kito.github.io/dantalion`.
- Solid Router internal state stays consistent with the URL bar.
- `<A>` href values and the resulting navigation both keep the
  `/dantalion/` prefix.

## Test plan

- [x] `pnpm run lint` exits zero
- [x] `pnpm run test` exits zero
- [x] `pnpm --filter @kurone-kito/dantalion-web-demo-web run build`
      succeeds; 40 SSG routes prerender unchanged
- [ ] CI matrix green — verified post-merge
- [ ] Manual: after merge + deploy, a Playwright probe submits the
      form, then clicks Open detail page / File ID / axis chips and
      observes all four destinations land at `/dantalion/<lang>/<genius>/`
      with HTTP 200.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
