### PR TITLE
test(web): add navigation + base-path e2e specs

### DIFF
--- a/packages/web/e2e/fixtures.ts
+++ b/packages/web/e2e/fixtures.ts
@@ -1,0 +1,26 @@
+import en from '../src/i18n/locales/en.json';
+import ja from '../src/i18n/locales/ja.json';
+
+export const locales = { en, ja } as const;
+export type LocaleId = keyof typeof locales;
+
+export const submitLabel = (locale: LocaleId): string =>
+  locales[locale].personalityForm.submitLabel;
+
+export const detailLinkLabel = (locale: LocaleId): string =>
+  locales[locale].personalityForm.detailLinkLabel;
+
+export const fileIdLabel = (locale: LocaleId): string =>
+  locales[locale].result.fileId;
+
+export const shareTriggerLabel = (locale: LocaleId): string =>
+  locales[locale].share.trigger;
+
+export const copyLinkLabel = (locale: LocaleId): string =>
+  locales[locale].share.items.copyLink;
+
+export const axisLabels = (locale: LocaleId) => ({
+  inner: locales[locale].geniusAxes.inner,
+  outer: locales[locale].geniusAxes.outer,
+  workStyle: locales[locale].geniusAxes.workStyle,
+});

--- a/packages/web/e2e/navigation.spec.ts
+++ b/packages/web/e2e/navigation.spec.ts
@@ -1,0 +1,145 @@
+import { type APIRequestContext, expect, test } from '@playwright/test';
+import {
+  axisLabels,
+  detailLinkLabel,
+  fileIdLabel,
+  type LocaleId,
+  submitLabel,
+} from './fixtures';
+
+const locales: readonly LocaleId[] = ['en', 'ja'];
+
+const fetchAbsolute = async (
+  request: APIRequestContext,
+  path: string,
+): Promise<number> => {
+  const baseHost = 'http://127.0.0.1:4173';
+  const response = await request.get(`${baseHost}${path}`);
+  return response.status();
+};
+
+test.describe('navigation + base path', () => {
+  test('the / entry resolves to /dantalion/<locale>/', async ({ page }) => {
+    await page.goto('/');
+    await expect(page).toHaveURL(/\/dantalion\/(en|ja)\/$/u);
+  });
+
+  for (const locale of locales) {
+    test(`every internal anchor on /dantalion/${locale}/ carries the /dantalion/ prefix`, async ({
+      page,
+    }) => {
+      await page.goto(`/dantalion/${locale}/`);
+      const internalHrefs = await page
+        .locator('a[href^="/"]')
+        .evaluateAll((els) => els.map((el) => el.getAttribute('href') ?? ''));
+      expect(internalHrefs.length).toBeGreaterThan(0);
+      for (const href of internalHrefs) {
+        expect
+          .soft(href, `bare anchor must carry /dantalion/: ${href}`)
+          .toMatch(/^\/dantalion\//u);
+      }
+    });
+
+    test(`every internal anchor on /dantalion/${locale}/100/ carries the /dantalion/ prefix`, async ({
+      page,
+    }) => {
+      await page.goto(`/dantalion/${locale}/100/`);
+      const internalHrefs = await page
+        .locator('a[href^="/"]')
+        .evaluateAll((els) => els.map((el) => el.getAttribute('href') ?? ''));
+      expect(internalHrefs.length).toBeGreaterThan(0);
+      for (const href of internalHrefs) {
+        expect
+          .soft(href, `bare anchor must carry /dantalion/: ${href}`)
+          .toMatch(/^\/dantalion\//u);
+      }
+    });
+  }
+
+  test('genius detail pages serve as static SSG assets with HTTP 200', async ({
+    request,
+  }) => {
+    expect.soft(await fetchAbsolute(request, '/dantalion/en/100/')).toBe(200);
+    expect.soft(await fetchAbsolute(request, '/dantalion/ja/100/')).toBe(200);
+    expect.soft(await fetchAbsolute(request, '/dantalion/en/555/')).toBe(200);
+  });
+
+  test('submitting the form keeps /dantalion/ in the URL bar', async ({
+    page,
+  }) => {
+    await page.goto('/dantalion/en/');
+    await page.fill('#nickname', 'Alice');
+    await page.getByRole('button', { name: submitLabel('en') }).click();
+    await expect(page).toHaveURL(
+      /\/dantalion\/en\/\?d=\d{4}-\d{2}-\d{2}&n=Alice/u,
+    );
+  });
+
+  test('clicking Open detail page lands on /dantalion/<lang>/<inner-genius>/', async ({
+    page,
+  }) => {
+    await page.goto('/dantalion/en/');
+    await page.getByRole('button', { name: submitLabel('en') }).click();
+    await expect(
+      page.getByRole('link', { name: detailLinkLabel('en') }).first(),
+    ).toBeVisible();
+    await page
+      .getByRole('link', { name: detailLinkLabel('en') })
+      .first()
+      .click();
+    await page.waitForURL(/\/dantalion\/en\/\d{3}\/$/u);
+    await expect(
+      page.getByRole('link', { name: /Find your genius/u }),
+    ).toBeVisible();
+  });
+
+  test('clicking the File ID badge lands on the genius detail page', async ({
+    page,
+  }) => {
+    await page.goto('/dantalion/en/');
+    await page.getByRole('button', { name: submitLabel('en') }).click();
+    const badge = page
+      .getByRole('link', { name: new RegExp(`^${fileIdLabel('en')}`, 'u') })
+      .first();
+    await expect(badge).toBeVisible();
+    await badge.click();
+    await page.waitForURL(/\/dantalion\/en\/\d{3}\/$/u);
+  });
+
+  test('clicking an axis chip lands on /dantalion/<lang>/<axis-genius>/', async ({
+    page,
+  }) => {
+    await page.goto('/dantalion/en/');
+    await page.getByRole('button', { name: submitLabel('en') }).click();
+    const labels = axisLabels('en');
+    const chip = page
+      .getByRole('link', {
+        name: new RegExp(`^${labels.inner}\\s+\\d{3}$`, 'u'),
+      })
+      .first();
+    await expect(chip).toBeVisible();
+    await chip.click();
+    await page.waitForURL(/\/dantalion\/en\/\d{3}\/$/u);
+  });
+
+  test('from a detail page, the CTA returns to /dantalion/<lang>/', async ({
+    page,
+  }) => {
+    await page.goto('/dantalion/en/100/');
+    const cta = page.getByRole('link', { name: /Find your genius/u }).first();
+    await expect(cta).toBeVisible();
+    await cta.click();
+    await page.waitForURL(/\/dantalion\/en\/$/u);
+  });
+
+  test('reopening /dantalion/en/?d=2000-01-01&n=Alice restores the result', async ({
+    page,
+  }) => {
+    await page.goto('/dantalion/en/?d=2000-01-01&n=Alice');
+    await expect(page.locator('input#birthday')).toHaveValue('2000-01-01');
+    await expect(page.locator('input#nickname')).toHaveValue('Alice');
+    await expect(
+      page.getByRole('heading', { name: "Alice's personality" }).first(),
+    ).toBeVisible();
+  });
+});


### PR DESCRIPTION
Closes #66.

## Summary
- New `packages/web/e2e/fixtures.ts` — small typed helpers that read the `en.json` / `ja.json` locale bundles so specs reference the same canonical labels as the UI.
- New `packages/web/e2e/navigation.spec.ts` — 12 scenarios (`expect.soft` for static-link audits) that pin down the `/dantalion/` base-path invariant and the click flows that previously 404'd before #62/#63.

## What's covered
1. `/` redirects to `/dantalion/<locale>/`.
2. Every internal `<a href="/...">` on `/dantalion/<lang>/` and `/dantalion/<lang>/100/` keeps the `/dantalion/` prefix (en + ja).
3. Genius detail pages (`/dantalion/<lang>/<genius>/`) serve as static SSG assets with HTTP 200.
4. Submitting the form keeps `/dantalion/` in the URL bar (#63 regression).
5. Click flows: Open detail page, File ID badge, axis chip, detail-page CTA back (#62 regression).
6. `?d=2000-01-01&n=Alice` permalink restores the result.

## Implementation notes
- `waitForResponse` won't fire on Solid Router client-side navigations; the click flows therefore assert via `waitForURL` and a follow-up `toBeVisible()` on the destination page's CTA. Static HTTP 200 is asserted via a separate `request.get(...)` test.
- Heading match for the apostrophe-bearing `Alice's personality` uses a plain string (a regex literal trips Playwright's selector parser).
- The "every internal anchor" scan uses `expect.soft` so a single offender produces a list of every bad href instead of stopping at the first.

## Test plan
- [x] `pnpm --filter @kurone-kito/dantalion-web-demo-web exec playwright test` → 15 passed (3 smoke + 12 navigation).
- [x] `pnpm --filter @kurone-kito/dantalion-web-demo-web run test:ts`
- [x] `pnpm lint`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added comprehensive end-to-end test coverage for application navigation and routing across supported locales.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/kurone-kito/dantalion-web-demo/pull/71?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->