### PR TITLE
test(web): add share menu + permalink e2e specs

### DIFF
--- a/packages/web/e2e/fixtures.ts
+++ b/packages/web/e2e/fixtures.ts
@@ -1,7 +1,29 @@
-import en from '../src/i18n/locales/en.json';
-import ja from '../src/i18n/locales/ja.json';
+import { readFileSync } from 'node:fs';
+import { fileURLToPath } from 'node:url';
 
-export const locales = { en, ja } as const;
+type Locale = {
+  geniusAxes: { inner: string; outer: string; workStyle: string };
+  personalityForm: { detailLinkLabel: string; submitLabel: string };
+  result: { fileId: string };
+  share: {
+    items: { copyLink: string };
+    trigger: string;
+  };
+};
+
+const loadLocale = (file: string): Locale =>
+  JSON.parse(
+    readFileSync(
+      fileURLToPath(new URL(`../src/i18n/locales/${file}`, import.meta.url)),
+      'utf8',
+    ),
+  ) as Locale;
+
+export const locales = {
+  en: loadLocale('en.json'),
+  ja: loadLocale('ja.json'),
+} as const;
+
 export type LocaleId = keyof typeof locales;
 
 export const submitLabel = (locale: LocaleId): string =>

--- a/packages/web/e2e/share-permalink.spec.ts
+++ b/packages/web/e2e/share-permalink.spec.ts
@@ -1,0 +1,139 @@
+import { expect, test } from '@playwright/test';
+import { copyLinkLabel, shareTriggerLabel, submitLabel } from './fixtures';
+
+const expectedShareUrlPattern =
+  /^http:\/\/127\.0\.0\.1:4173\/dantalion\/en\/result\/\d{3}-\d{3}-\d{3}\/(\?n=Alice)?$/u;
+
+const openShareMenu = async (page: import('@playwright/test').Page) => {
+  const trigger = page.getByRole('button', { name: shareTriggerLabel('en') });
+  await expect(trigger).toBeVisible();
+  await trigger.focus();
+};
+
+const submitAlice = async (page: import('@playwright/test').Page) => {
+  await page.goto('/dantalion/en/');
+  await page.fill('#birthday', '2000-01-01');
+  await page.fill('#nickname', 'Alice');
+  await page.getByRole('button', { name: submitLabel('en') }).click();
+  await expect(
+    page.getByRole('heading', { name: "Alice's personality" }).first(),
+  ).toBeVisible();
+};
+
+test.describe('share menu + permalink', () => {
+  test('Copy link writes the genius-derived URL to the clipboard with no birthday leak', async ({
+    page,
+    context,
+  }) => {
+    await context.grantPermissions(['clipboard-read', 'clipboard-write']);
+    await submitAlice(page);
+    await openShareMenu(page);
+    await page.evaluate((label) => {
+      const target = Array.from(
+        document.querySelectorAll<HTMLButtonElement>(
+          '.dropdown-content button',
+        ),
+      ).find((el) => el.textContent?.trim() === label);
+      target?.click();
+    }, copyLinkLabel('en'));
+    await expect(
+      page.getByText('Permalink copied to clipboard').first(),
+    ).toBeVisible();
+    const clipboard = await page.evaluate(() => navigator.clipboard.readText());
+    expect(clipboard).toMatch(expectedShareUrlPattern);
+    expect(clipboard).not.toContain('?d=');
+    expect(clipboard).not.toContain('2000-01-01');
+  });
+
+  test('X compose intent encodes the leak-free share URL', async ({ page }) => {
+    await submitAlice(page);
+    await openShareMenu(page);
+    const href = await page
+      .getByRole('link', { name: 'Share on X' })
+      .getAttribute('href');
+    expect(href).toBeTruthy();
+    const intent = new URL(href ?? '');
+    expect(intent.origin).toBe('https://x.com');
+    expect(intent.pathname).toBe('/intent/post');
+    const sharedUrl = intent.searchParams.get('url') ?? '';
+    expect(sharedUrl).toMatch(expectedShareUrlPattern);
+    expect(sharedUrl).not.toContain('?d=');
+    expect(sharedUrl).not.toContain('2000-01-01');
+  });
+
+  test('Bluesky compose intent encodes the leak-free share URL', async ({
+    page,
+  }) => {
+    await submitAlice(page);
+    await openShareMenu(page);
+    const href = await page
+      .getByRole('link', { name: 'Share on Bluesky' })
+      .getAttribute('href');
+    expect(href).toBeTruthy();
+    const intent = new URL(href ?? '');
+    expect(intent.origin).toBe('https://bsky.app');
+    expect(intent.pathname).toBe('/intent/compose');
+    const text = intent.searchParams.get('text') ?? '';
+    expect(text).toMatch(/\/dantalion\/en\/result\/\d{3}-\d{3}-\d{3}\//u);
+    expect(text).not.toContain('?d=');
+    expect(text).not.toContain('2000-01-01');
+  });
+
+  test('personal-use ?d= state never appears in share URLs', async ({
+    page,
+  }) => {
+    await submitAlice(page);
+    await expect(page).toHaveURL(/\?d=2000-01-01&n=Alice/u);
+    await openShareMenu(page);
+    const xHref =
+      (await page
+        .getByRole('link', { name: 'Share on X' })
+        .getAttribute('href')) ?? '';
+    const blueskyHref =
+      (await page
+        .getByRole('link', { name: 'Share on Bluesky' })
+        .getAttribute('href')) ?? '';
+    for (const href of [xHref, blueskyHref]) {
+      expect.soft(href).not.toContain('d%3D2000-01-01');
+      expect.soft(href).not.toContain('?d=');
+      expect.soft(href).not.toContain('2000-01-01');
+    }
+  });
+
+  // Static SSG ships only prerendered detail-page paths; the result-triple
+  // route is dynamic and not currently emitted as an HTML asset, so cold
+  // loads (the recipient path for X / Bluesky share links) land on the 404
+  // shell. Tracked in #72 — flipping this back to `test()` is the acceptance
+  // signal that the SPA fallback works.
+  test.fixme('visiting a result-triple URL renders the axis panel and per-axis bodies', async ({
+    page,
+  }) => {
+    await page.goto('/dantalion/en/result/555-001-888/?n=Alice');
+    await expect(
+      page.getByRole('heading', { name: /Three personalities/u }).first(),
+    ).toBeVisible();
+    await expect(
+      page.getByRole('link', { name: /^Inner\s+555$/u }),
+    ).toBeVisible();
+    await expect(
+      page.getByRole('link', { name: /^Outer\s+001$/u }),
+    ).toBeVisible();
+    await expect(
+      page.getByRole('link', { name: /^Work style\s+888$/u }),
+    ).toBeVisible();
+    expect(page.url()).not.toContain('?d=');
+    expect(await page.locator('input#birthday').count()).toBe(0);
+  });
+
+  test('cold-loading any non-prerendered URL serves the localized not-found shell', async ({
+    page,
+  }) => {
+    const response = await page.goto('/dantalion/en/result/100-108-bogus/');
+    expect(response?.status()).toBe(404);
+    await expect(
+      page
+        .getByText(/page you requested|not part of this static demo/u)
+        .first(),
+    ).toBeVisible();
+  });
+});


### PR DESCRIPTION
Closes #67. Surfaces #72 as a follow-up for the cold-load SSG gap.

## Summary
- New `packages/web/e2e/share-permalink.spec.ts` pinning the v1.1.1 share-URL contract: every entry hands off `/dantalion/<lang>/result/<inner>-<outer>-<workStyle>/[?n=...]` with no `?d=` and no birthday substring.
- Extends `e2e/fixtures.ts` with `shareTriggerLabel` / `copyLinkLabel` and switches the locale loader to `readFileSync` + `JSON.parse` so the same fixtures module works under both `tsc -p tsconfig.test.json` (module: es2022) and Playwright's Node loader.
- Opens **#72** for the cold-load SSG gap and marks the corresponding spec block as `test.fixme` with a pointer to that follow-up — flipping it back to `test()` is the acceptance signal that the fix landed.

## Spec blocks
| Block | Status |
| --- | --- |
| Copy link writes the leak-free URL to the clipboard | ✅ |
| X compose intent encodes the leak-free URL | ✅ |
| Bluesky compose intent encodes the leak-free URL | ✅ |
| Personal `?d=` state never appears in share URLs | ✅ |
| Cold-load to a non-prerendered URL serves the 404 shell | ✅ |
| Visiting a result-triple URL renders the panel | ⏸ `test.fixme` → #72 |

## Implementation notes
- DaisyUI's `.dropdown-content` intercepts pointer events until the trigger is focused. `openShareMenu` focuses the trigger; the Copy link click is dispatched via `page.evaluate` so the test does not depend on focus-within timing.
- Clipboard verification waits for the "Permalink copied to clipboard" toast before reading `navigator.clipboard.readText()`, so a silent clipboard-write failure surfaces as a missing toast rather than an empty string.
- The result-triple cold-load block (`test.fixme`) intentionally documents the gap: a `404.html` shell hydrates as `NotFoundPage` instead of rerouting via `<FileRoutes />`, so X / Bluesky recipients currently can't open the link. #72 lays out the candidate SPA-fallback approaches.

## Test plan
- [x] `pnpm --filter @kurone-kito/dantalion-web-demo-web exec playwright test` → 20 passed, 1 skipped (the `fixme` block).
- [x] `pnpm --filter @kurone-kito/dantalion-web-demo-web run test:ts`
- [x] `pnpm lint`
- [x] `pnpm test`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added comprehensive test coverage for share functionality, validating that personal data is excluded from shared links across platforms (copy link, X, Bluesky).
  * Added tests for proper 404 error handling when accessing non-existent content.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/kurone-kito/dantalion-web-demo/pull/73?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->