### PR TITLE
test(web): add SSG + i18n parity e2e specs

### DIFF
--- a/packages/web/e2e/fixtures.ts
+++ b/packages/web/e2e/fixtures.ts
@@ -2,7 +2,12 @@ import { readFileSync } from 'node:fs';
 import { fileURLToPath } from 'node:url';
 
 type Locale = {
+  demoPage: { title: string };
   geniusAxes: { inner: string; outer: string; workStyle: string };
+  landing: {
+    feature: { title: string };
+    install: { title: string };
+  };
   personalityForm: { detailLinkLabel: string; submitLabel: string };
   result: { fileId: string };
   share: {

--- a/packages/web/e2e/ssg-i18n.spec.ts
+++ b/packages/web/e2e/ssg-i18n.spec.ts
@@ -1,0 +1,162 @@
+import { type APIRequestContext, expect, test } from '@playwright/test';
+import { locales } from './fixtures';
+
+const enLandingMarkers = {
+  feature: locales.en.landing.feature.title,
+  hero: locales.en.demoPage.title,
+  install: locales.en.landing.install.title,
+};
+
+const jaLandingMarkers = {
+  feature: locales.ja.landing.feature.title,
+  hero: locales.ja.demoPage.title,
+  install: locales.ja.landing.install.title,
+};
+
+const detailMarkers = {
+  en: {
+    h1: /Dantalion: Details of people/u,
+    h2: /Major categories of personality/u,
+    leak: '性格の大分類',
+  },
+  ja: {
+    h1: /Dantalion: 性格タイプ \d{3} の詳細/u,
+    h2: /性格の大分類/u,
+    leak: 'Major categories of personality',
+  },
+} as const;
+
+const sampleGeniusIds = ['000', '100', '919'] as const;
+
+const fetchText = async (
+  request: APIRequestContext,
+  path: string,
+): Promise<{ status: number; body: string }> => {
+  const response = await request.get(`http://127.0.0.1:4173${path}`);
+  return { status: response.status(), body: await response.text() };
+};
+
+test.describe('SSG + i18n parity', () => {
+  test('the EN home page renders the English landing copy', async ({
+    page,
+  }) => {
+    await page.goto('/dantalion/en/');
+    await expect(
+      page.getByRole('heading', { name: enLandingMarkers.hero }).first(),
+    ).toBeVisible();
+    await expect(
+      page.getByRole('heading', { name: enLandingMarkers.feature }),
+    ).toBeVisible();
+    await expect(
+      page.getByRole('heading', { name: enLandingMarkers.install }),
+    ).toBeVisible();
+  });
+
+  test('the JA home page renders the Japanese landing copy', async ({
+    page,
+  }) => {
+    await page.goto('/dantalion/ja/');
+    await expect(
+      page.getByRole('heading', { name: jaLandingMarkers.hero }).first(),
+    ).toBeVisible();
+    await expect(
+      page.getByRole('heading', { name: jaLandingMarkers.feature }),
+    ).toBeVisible();
+    await expect(
+      page.getByRole('heading', { name: jaLandingMarkers.install }),
+    ).toBeVisible();
+  });
+
+  for (const code of sampleGeniusIds) {
+    test(`/dantalion/en/${code}/ contains English markdown markers and no JA leak`, async ({
+      request,
+    }) => {
+      const { status, body } = await fetchText(
+        request,
+        `/dantalion/en/${code}/`,
+      );
+      expect(status).toBe(200);
+      expect(body).toMatch(detailMarkers.en.h1);
+      expect(body).toMatch(detailMarkers.en.h2);
+      expect(body).not.toContain(detailMarkers.en.leak);
+    });
+
+    test(`/dantalion/ja/${code}/ contains Japanese markdown markers and no EN leak`, async ({
+      request,
+    }) => {
+      const { status, body } = await fetchText(
+        request,
+        `/dantalion/ja/${code}/`,
+      );
+      expect(status).toBe(200);
+      expect(body).toMatch(detailMarkers.ja.h1);
+      expect(body).toMatch(detailMarkers.ja.h2);
+      expect(body).not.toContain(detailMarkers.ja.leak);
+    });
+  }
+
+  test('hreflang alternates on /en/100/ point at /ja/100/ and x-default falls back to en', async ({
+    page,
+  }) => {
+    await page.goto('/dantalion/en/100/');
+    const alternates = await page
+      .locator('link[rel="alternate"][hreflang]')
+      .evaluateAll((els) =>
+        els.map((el) => ({
+          hreflang: el.getAttribute('hreflang'),
+          href: el.getAttribute('href'),
+        })),
+      );
+    const enAlt = alternates.find((a) => a.hreflang === 'en');
+    const jaAlt = alternates.find((a) => a.hreflang === 'ja');
+    const xDefault = alternates.find((a) => a.hreflang === 'x-default');
+    expect(enAlt?.href).toMatch(/\/dantalion\/en\/100\/$/u);
+    expect(jaAlt?.href).toMatch(/\/dantalion\/ja\/100\/$/u);
+    expect(xDefault?.href).toMatch(/\/dantalion\/en\/100\/$/u);
+  });
+
+  test('the legacy /100.html alias replaces the URL with the locale-pinned path', async ({
+    page,
+  }) => {
+    await page.goto('/dantalion/100.html');
+    await page.waitForURL(/\/dantalion\/(en|ja)\/100\/?$/u);
+    expect(page.url()).toMatch(/\/dantalion\/(en|ja)\/100\/?$/u);
+  });
+
+  test('the legacy /100.html alias is served as a 200 asset with the canonical chrome', async ({
+    request,
+  }) => {
+    const { status, body } = await fetchText(request, '/dantalion/100.html');
+    expect(status).toBe(200);
+    expect(body).toMatch(/Genius 100/u);
+    expect(body).toContain('<html lang="en"');
+  });
+
+  // The legacy /<N>.html aliases SSR with the polluted i18next singleton
+  // (see #74) and currently ship Japanese detail markdown under the
+  // EN-default chrome. Flipping this back to `test()` is the acceptance
+  // signal that #74 landed.
+  test.fixme('the legacy /100.html SSR ships the EN genius detail copy (no JA leak)', async ({
+    request,
+  }) => {
+    const { body } = await fetchText(request, '/dantalion/100.html');
+    expect(body).toMatch(detailMarkers.en.h1);
+    expect(body).not.toContain(detailMarkers.en.leak);
+  });
+
+  test('robots.txt and sitemap.xml are served from the deploy root', async ({
+    request,
+  }) => {
+    const robots = await fetchText(request, '/dantalion/robots.txt');
+    expect(robots.status).toBe(200);
+    expect(robots.body).toContain('Sitemap:');
+    expect(robots.body).toContain('/sitemap.xml');
+
+    const sitemap = await fetchText(request, '/dantalion/sitemap.xml');
+    expect(sitemap.status).toBe(200);
+    expect(sitemap.body).toContain('<urlset');
+    expect(sitemap.body).toContain('/dantalion/en/');
+    expect(sitemap.body).toContain('/dantalion/ja/');
+    expect(sitemap.body).toContain('/dantalion/en/100/');
+  });
+});


### PR DESCRIPTION
Closes #68. Surfaces #74 as a follow-up for the legacy `/<N>.html` alias i18n leak the new spec uncovered.

## Summary
- New `packages/web/e2e/ssg-i18n.spec.ts` pins the deploy-shaped output that #62's prerender-crawler bug class would silently corrupt. Both presence of the expected-locale marker and absence of the other-locale marker are asserted on every genius-detail page.
- Extends `e2e/fixtures.ts`'s `Locale` type to expose `landing` / `demoPage`, so the home-page assertions pin against the JSON resource files directly instead of duplicating strings.
- Opens **#74** for a real bug the spec uncovered: every `/dantalion/<N>.html` legacy alias currently ships **Japanese** detail markdown under the `<html lang="en">` chrome. Same i18next-singleton-pollution class as #62, but for the legacy route. The corresponding spec block is marked `test.fixme` and references #74.

## Spec blocks
| Block | Status |
| --- | --- |
| EN home page renders English landing copy | ✅ |
| JA home page renders Japanese landing copy | ✅ |
| `/en/<000\|100\|919>/` ship English markers, no JA leak | ✅ |
| `/ja/<000\|100\|919>/` ship Japanese markers, no EN leak | ✅ |
| `hreflang` alternates on `/en/100/` point at `en/100`, `ja/100`, `x-default → en/100` | ✅ |
| `/100.html` legacy alias replaces the URL with the locale-pinned path | ✅ |
| `/100.html` is served as a 200 asset with the canonical EN chrome | ✅ |
| `/100.html` SSR ships the EN genius detail copy with no JA leak | ⏸ `test.fixme` → #74 |
| `robots.txt` / `sitemap.xml` are emitted at the deploy root | ✅ |

## Test plan
- [x] `pnpm --filter @kurone-kito/dantalion-web-demo-web exec playwright test` → 32 passed, 2 skipped (`fixme`s from #67/#68).
- [x] `pnpm --filter @kurone-kito/dantalion-web-demo-web run test:ts`
- [x] `pnpm lint`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added comprehensive end-to-end testing for internationalization and server-side generation across English and Japanese routes.
  * Validates language-specific page rendering, alternate language links, legacy URL redirects, and SEO assets (robots.txt, sitemap.xml).

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/kurone-kito/dantalion-web-demo/pull/75?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->