### PR TITLE
ci(web): wire Playwright into the CI matrix

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -42,3 +42,38 @@ jobs:
       - run: pnpm run lint
       - run: pnpm run test
       - run: pnpm --filter @kurone-kito/dantalion-web-demo-web run story:build
+
+  e2e:
+    name: e2e (chromium)
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    steps:
+      - uses: actions/checkout@v6
+      - uses: pnpm/action-setup@v6
+        with:
+          run_install: false
+      - uses: actions/setup-node@v6
+        with:
+          cache: pnpm
+          node-version: 24
+      - run: corepack enable
+      - env:
+          HUSKY: 0
+        run: pnpm install --frozen-lockfile --prefer-offline
+      - name: Cache Playwright browsers
+        uses: actions/cache@v4
+        with:
+          path: ~/.cache/ms-playwright
+          key: playwright-${{ runner.os }}-${{ hashFiles('pnpm-lock.yaml') }}
+          restore-keys: |
+            playwright-${{ runner.os }}-
+      - run: pnpm exec playwright install --with-deps chromium
+      - run: pnpm --filter @kurone-kito/dantalion-web-demo-web run test:e2e
+      - if: failure()
+        uses: actions/upload-artifact@v4
+        with:
+          name: playwright-report
+          path: |
+            packages/web/playwright-report
+            packages/web/test-results
+          retention-days: 7

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -67,7 +67,7 @@ jobs:
           key: playwright-${{ runner.os }}-${{ hashFiles('pnpm-lock.yaml') }}
           restore-keys: |
             playwright-${{ runner.os }}-
-      - run: pnpm exec playwright install --with-deps chromium
+      - run: pnpm --filter @kurone-kito/dantalion-web-demo-web exec playwright install --with-deps chromium
       - run: pnpm --filter @kurone-kito/dantalion-web-demo-web run test:e2e
       - if: failure()
         uses: actions/upload-artifact@v4

--- a/packages/web/README.md
+++ b/packages/web/README.md
@@ -66,6 +66,13 @@ on `127.0.0.1:4173/dantalion/` before each invocation. Specs live in
 `packages/web/e2e/` and target the deploy-shaped base path so the
 checks mirror what `gh-pages` serves.
 
+The same suite runs as the `e2e (chromium)` job on every PR alongside
+`validate (Node 22.22.2)` / `validate (Node 24)`. Failing runs upload a
+`playwright-report` artefact (HTML report + per-spec trace, screenshot,
+video) under the workflow run's artefacts panel — download it to debug
+locally with `pnpm --filter @kurone-kito/dantalion-web-demo-web exec
+playwright show-report`.
+
 ## Component catalog
 
 `pnpm --filter @kurone-kito/dantalion-web-demo-web run story:dev` boots


### PR DESCRIPTION
Closes #69.

## Summary
- Adds `e2e (chromium)` to `.github/workflows/ci.yml` running alongside the existing `validate` matrix (no `needs:` chain — parallel for shortest wall-clock).
- Caches `~/.cache/ms-playwright` keyed on `pnpm-lock.yaml`, so a Playwright bump invalidates the cache automatically and warm runs skip the ~150 MB browser download.
- Installs Chromium with `playwright install --with-deps chromium`; no other engines are needed today.
- Uploads `packages/web/playwright-report` + `test-results` as the `playwright-report` artefact on failure (7-day retention), so traces, screenshots, and videos survive long enough to debug from.
- Documents the new gate and artefact debug path in `packages/web/README.md`.

## Trade-offs
- Runs on Node 24 only. The browser is the regression surface, not the Node runtime, and the navigation specs already cover Solid Router + Vinxi production behavior the same way both Node versions of `validate` would.
- The 15-minute timeout leaves ~9 minutes of slack over the cold-cache install + browser fetch + suite, in line with the issue's acceptance budget.

## Test plan
- [x] `pnpm run lint`
- [x] Local `pnpm --filter @kurone-kito/dantalion-web-demo-web run test:e2e` passes against current `main` (32 tests + 2 documented `test.fixme`).
- [ ] First push of this PR exercises the new `e2e (chromium)` gate — wait for that run to validate cold-cache wall-clock and artefact upload format.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Added end-to-end testing to the continuous integration pipeline using Playwright with Chromium browser, running on every PR.

* **Documentation**
  * Updated README with instructions for CI/E2E test behavior and how to view test reports locally when failures occur.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/kurone-kito/dantalion-web-demo/pull/76?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->