### PR TITLE
fix(web): re-resolve accessors so per-locale prerender isn't poisoned

### DIFF
--- a/packages/web/e2e/ssg-i18n.spec.ts
+++ b/packages/web/e2e/ssg-i18n.spec.ts
@@ -132,11 +132,7 @@ test.describe('SSG + i18n parity', () => {
     expect(body).toContain('<html lang="en"');
   });
 
-  // The legacy /<N>.html aliases SSR with the polluted i18next singleton
-  // (see #74) and currently ship Japanese detail markdown under the
-  // EN-default chrome. Flipping this back to `test()` is the acceptance
-  // signal that #74 landed.
-  test.fixme('the legacy /100.html SSR ships the EN genius detail copy (no JA leak)', async ({
+  test('the legacy /100.html SSR ships the EN genius detail copy (no JA leak)', async ({
     request,
   }) => {
     const { body } = await fetchText(request, '/dantalion/100.html');

--- a/packages/web/src/lib/dantalion.ts
+++ b/packages/web/src/lib/dantalion.ts
@@ -32,20 +32,18 @@ export const geniusTypeValues = geniusTypes.map(String);
 
 export const supportedLanguages = [...supportedLanguageValues];
 
-const accessorsCache = new Map<SupportedLanguage, Promise<Accessors>>();
 const supportedGeniusSet = new Set<string>(geniusTypeValues);
 
-const getAccessorsFor = (language: SupportedLanguage): Promise<Accessors> => {
-  const cached = accessorsCache.get(language);
-
-  if (cached) {
-    return cached;
-  }
-
-  const accessors = createAccessorsAsync(language);
-  accessorsCache.set(language, accessors);
-  return accessors;
-};
+// dantalion-i18n's `createAccessorsAsync(language)` calls `i18next.init({ lng })`
+// against the shared singleton. Caching the resulting Accessors bundle is unsafe
+// across languages — a later JA call mutates the singleton, and a subsequent EN
+// read against a cached Accessors bundle resolves through that polluted state.
+// Always re-resolve so the singleton is locked to the requested language before
+// `t()` runs. This is the durable fix for the prerender leak that #62 mitigated
+// with `crawlLinks: false` and #74 surfaced again in the legacy `/<N>.html`
+// aliases.
+const getAccessorsFor = (language: SupportedLanguage): Promise<Accessors> =>
+  createAccessorsAsync(language);
 
 export const getPersonalityFor = (birthday: Date): Personality => {
   const personality = getPersonality(birthday);


### PR DESCRIPTION
Closes #74.

## Summary
- dantalion-i18n's `createAccessorsAsync(language)` calls `i18next.init({ lng })` against the shared singleton. Caching the resulting Accessors bundle is **unsafe across languages**: a later JA call mutates the singleton, then a subsequent EN read against a cached Accessors bundle resolves through that polluted state.
- #62 sidestepped this with `prerender.crawlLinks: false`; #74 surfaced the same leak in the legacy `/<N>.html` aliases, which prerender after the JA detail routes and were shipping JA markdown under the EN-default `<html lang="en">` chrome.
- Drops the `accessorsCache` in `packages/web/src/lib/dantalion.ts` and re-resolves via `createAccessorsAsync` on every call so the singleton is locked to the requested language before `t()` runs. The `init()` resources object reuses the already-loaded JSON, so the cost is small (one `i18next.init` per read instead of one per language).

## Verification
Before:
```
$ grep -ohE 'Dantalion[:：][^<"\\x]{0,30}' .output/public/100.html
Dantalion: 性格タイプ
```
After:
```
$ grep -c 'Dantalion: Details of people' .output/public/{000,100,919}.html
.output/public/000.html:1
.output/public/100.html:1
.output/public/919.html:1
$ grep -c '性格の大分類' .output/public/{000,100,919}.html
.output/public/000.html:0
.output/public/100.html:0
.output/public/919.html:0
```

The `test.fixme` block at `e2e/ssg-i18n.spec.ts` flips back to a passing `test()` block.

## Test plan
- [x] `pnpm --filter @kurone-kito/dantalion-web-demo-web run build` (cold rebuild)
- [x] `pnpm --filter @kurone-kito/dantalion-web-demo-web exec playwright test` → 33 passed, 1 skipped (#72 fixme only)
- [x] `pnpm lint`
- [x] `pnpm test`

🤖 Generated with [Claude Code](https://claude.com/claude-code)