### PR TITLE
feat(web): SPA fallback for result-triple cold loads

### DIFF
--- a/packages/web/e2e/share-permalink.spec.ts
+++ b/packages/web/e2e/share-permalink.spec.ts
@@ -100,12 +100,7 @@ test.describe('share menu + permalink', () => {
     }
   });
 
-  // Static SSG ships only prerendered detail-page paths; the result-triple
-  // route is dynamic and not currently emitted as an HTML asset, so cold
-  // loads (the recipient path for X / Bluesky share links) land on the 404
-  // shell. Tracked in #72 — flipping this back to `test()` is the acceptance
-  // signal that the SPA fallback works.
-  test.fixme('visiting a result-triple URL renders the axis panel and per-axis bodies', async ({
+  test('visiting a result-triple URL renders the axis panel and per-axis bodies', async ({
     page,
   }) => {
     await page.goto('/dantalion/en/result/555-001-888/?n=Alice');
@@ -121,6 +116,7 @@ test.describe('share menu + permalink', () => {
     await expect(
       page.getByRole('link', { name: /^Work style\s+888$/u }),
     ).toBeVisible();
+    await expect(page).toHaveURL(/\/dantalion\/en\/result\/555-001-888\//u);
     expect(page.url()).not.toContain('?d=');
     expect(await page.locator('input#birthday').count()).toBe(0);
   });

--- a/packages/web/scripts/postbuild.mjs
+++ b/packages/web/scripts/postbuild.mjs
@@ -1,4 +1,4 @@
-import { mkdir, writeFile } from 'node:fs/promises';
+import { mkdir, readFile, writeFile } from 'node:fs/promises';
 import { join } from 'node:path';
 import { fileURLToPath } from 'node:url';
 import { types } from '@kurone-kito/dantalion-core';
@@ -6,6 +6,8 @@ import { types } from '@kurone-kito/dantalion-core';
 const packageDir = fileURLToPath(new URL('..', import.meta.url));
 const outputDir = join(packageDir, '.output', 'public');
 const defaultSiteOrigin = 'https://kurone-kito.github.io/dantalion';
+const basePath =
+  process.env['BASE_PATH']?.trim().replace(/\/+$/u, '') || '/dantalion';
 const geniusTypeValues = types.genius.map(String);
 const siteOrigin = normalizeSiteOrigin(
   process.env['SITE_ORIGIN'] ??
@@ -24,6 +26,8 @@ const sitemapPaths = [
 await mkdir(outputDir, { recursive: true });
 await writeFile(join(outputDir, 'robots.txt'), buildRobotsTxt(siteOrigin));
 await writeFile(join(outputDir, 'sitemap.xml'), buildSitemapXml(siteOrigin));
+
+await injectSpaFallbackBridge();
 
 function normalizeSiteOrigin(value) {
   return value.trim().replace(/\/+$/u, '');
@@ -59,4 +63,37 @@ function escapeXml(value) {
     .replaceAll('>', '&gt;')
     .replaceAll('"', '&quot;')
     .replaceAll("'", '&apos;');
+}
+
+// The result-triple route (/<lang>/result/<inner>-<outer>-<workStyle>/) is the
+// recipient path for share URLs from #67 and is intentionally never prerendered
+// (12³ × 2 = 3,456 routes is too much). Cold loads from X / Bluesky / Slack
+// land on GH Pages's `404.html`, where Solid Start's client hydration locks to
+// the SSR'd NotFoundPage and the Router does not re-render the matching route.
+//
+// This bridge injects an inline `<script>` that runs *before* Solid hydrates:
+//
+// - In 404.html: if the URL is a known SPA route, capture it in
+//   sessionStorage and redirect to the prerendered locale home (`/<lang>/`).
+// - In the locale home pages: if sessionStorage contains a pending SPA path,
+//   `history.replaceState` to it before hydration so Solid Router matches the
+//   intended route from the start.
+//
+// Tracked: #72 (this fix), #67 (E2E spec, `share-permalink.spec.ts:108`).
+async function injectSpaFallbackBridge() {
+  // Runs inside `404.html` only. Captures the cold-load URL in sessionStorage
+  // and hard-redirects to the prerendered locale home (`/<lang>/`). The
+  // locale home reads sessionStorage from its own `onMount` and navigates via
+  // Solid Router — that way hydration completes against matching SSR DOM
+  // first, avoiding the hydration mismatch that would otherwise crash the
+  // `_triple_` chunk with "Cannot read properties of null".
+  const inlineScript = `<script>(function(){try{var b=${JSON.stringify(basePath)};var k='__dantalion_spa_path';var loc=window.location;var path=loc.pathname.indexOf(b)===0?loc.pathname.slice(b.length):loc.pathname;var match=/^\\/(en|ja)\\/result\\/[^/]+\\/?$/.exec(path);if(match){try{sessionStorage.setItem(k,path+loc.search);}catch(e){}loc.replace(b+'/'+match[1]+'/');}}catch(e){}})();</script>`;
+
+  const target = join(outputDir, '404.html');
+  const html = await readFile(target, 'utf8');
+  if (html.includes('__dantalion_spa_path')) {
+    return;
+  }
+  const updated = html.replace(/<head>/u, `<head>${inlineScript}`);
+  await writeFile(target, updated);
 }

--- a/packages/web/src/routes/[lang]/index.tsx
+++ b/packages/web/src/routes/[lang]/index.tsx
@@ -1,3 +1,5 @@
+import { useNavigate } from '@solidjs/router';
+import { onMount } from 'solid-js';
 import { FeatureSection } from '../../components/landing/feature-section';
 import { HeroSection } from '../../components/landing/hero-section';
 import { InstallSection } from '../../components/landing/install-section';
@@ -9,9 +11,32 @@ import { RouteMeta } from '../../components/route-meta';
 import { getDemoPageCopy } from '../../lib/demo-page';
 import { useLocale } from '../../lib/locale-context';
 
+const SPA_FALLBACK_STORAGE_KEY = '__dantalion_spa_path';
+
 export default function LocalizedHome() {
   const { language } = useLocale();
   const copy = () => getDemoPageCopy(language());
+  const navigate = useNavigate();
+
+  // 404.html's bridge script stashes the original cold-load URL in
+  // sessionStorage and hard-redirects to this locale home so hydration has a
+  // matching SSR shell. Once hydration is done, navigate via Solid Router to
+  // the original URL so the `[lang]/result/[triple].tsx` route renders in
+  // place. See #72 and `scripts/postbuild.mjs`.
+  onMount(() => {
+    let pending: string | null = null;
+    try {
+      pending = sessionStorage.getItem(SPA_FALLBACK_STORAGE_KEY);
+      if (pending) {
+        sessionStorage.removeItem(SPA_FALLBACK_STORAGE_KEY);
+      }
+    } catch {
+      // sessionStorage may be unavailable (private mode, sandboxed iframe).
+    }
+    if (pending) {
+      navigate(pending, { replace: true });
+    }
+  });
 
   return (
     <>


### PR DESCRIPTION
Closes #72.

## Summary
The v1.1.1 share URL is `/dantalion/<lang>/result/<inner>-<outer>-<workStyle>/`, intentionally not prerendered (12³ × 2 = 3,456 routes). Cold loads from X / Bluesky / Slack land on `404.html` with HTTP 404, and Solid Start's client locks hydration to the SSR'd `NotFoundPage` — the recipient saw "Page not found" instead of the shared personality.

Adds a two-step SPA bridge:

1. **`scripts/postbuild.mjs`** injects an inline `<head>` script into `404.html` that detects the result-triple URL shape, stashes the original path in `sessionStorage`, and hard-redirects to the prerendered locale home (`/dantalion/<lang>/`).
2. **`routes/[lang]/index.tsx`** reads `sessionStorage` from its own `onMount` and calls `navigate(pending, { replace: true })`. Doing the route swap *after* hydration completes against the matching locale-home SSR shell sidesteps the "Cannot read properties of null" hydration crash that plain `history.replaceState` in the bridge script produces.

## Why redirect → navigate (vs in-place `replaceState`)
Tried `history.replaceState` inside the inline 404 bridge first; Solid then hydrated `[lang]/result/[triple]` against the 404 SSR DOM and crashed in the `_triple_` chunk. The two-step path costs one extra navigation but keeps each hydration pass matched to its SSR shell.

## Verification
```
$ pnpm --filter @kurone-kito/dantalion-web-demo-web exec playwright test
... 34 passed ...
```

The `test.fixme` block at `share-permalink.spec.ts:108` is now a passing `test()` and gains a `toHaveURL` assertion so a future bridge regression re-fails the suite cleanly.

Cold-load manual probe through `scripts/preview.mjs`:
```
GET /dantalion/en/result/555-001-888/?n=Alice
→ 404.html (status 404) → bridge stashes /en/result/555-001-888/?n=Alice in sessionStorage
→ location.replace('/dantalion/en/')
→ /en/index.html (status 200) hydrates → onMount reads sessionStorage → navigate('/en/result/555-001-888/?n=Alice')
→ Three personalities panel renders, URL bar shows /dantalion/en/result/555-001-888/?n=Alice
```

## Test plan
- [x] `pnpm --filter @kurone-kito/dantalion-web-demo-web run build` (cold rebuild — injection confirmed on `404.html` only; locale-home `<head>` is untouched).
- [x] `pnpm --filter @kurone-kito/dantalion-web-demo-web exec playwright test` → 34 passed.
- [x] `pnpm lint`
- [x] `pnpm --filter @kurone-kito/dantalion-web-demo-web run test:ts`

🤖 Generated with [Claude Code](https://claude.com/claude-code)